### PR TITLE
SSE optimization, screenshots in PNG format

### DIFF
--- a/Makefile.MinGW
+++ b/Makefile.MinGW
@@ -9,7 +9,7 @@ DESTDIR=bin32/
 
 # -------------------------------
 
-OBJS = 	main.o font.o frame.o frame-pp.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o lua.o gravitrc.o
+OBJS = 	main.o font.o frame.o frame-pp.o frame-pp_sse.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o lua.o png_save.o gravitrc.o
 
 
 # -------------------------------
@@ -18,15 +18,14 @@ OBJS = 	main.o font.o frame.o frame-pp.o frame-ot.o gfx.o input.o console.o osd.
 P4C2opt=-mtune=core2 -march=core2 \
 	-msse -msse2 -msse3 -mssse3 -mfpmath=sse \
 	-fomit-frame-pointer -momit-leaf-frame-pointer \
-	-floop-optimize -funsafe-loop-optimizations -Wunsafe-loop-optimizations
+	-floop-optimize -funsafe-loop-optimizations -Wunsafe-loop-optimizations \
+	-malign-stringops \
+	-falign-functions=6 \
+	-falign-loops=6 \
+	-falign-jumps=6
 
-#	-malign-stringops
-#	-minline-stringops-dynamically \
-# 	-mfpmath=sse \
 #	-mpreferred-stack-boundary=6 \
-#	-falign-functions=6 \
-#	-falign-loops=6 \
-#	-falign-jumps=6
+#	-minline-stringops-dynamically \
 #	-mstackrealign
 
 
@@ -46,7 +45,7 @@ X64opt= -mtune=corei7 -march=corei7 \
 
 # -------------------------------
 
-CFLAGS = -DWITH_LUA -DHAVE_LUA -DUSE_PTHREAD \
+CFLAGS = -DWITH_LUA -DHAVE_LUA -DHAVE_SSE -DHAVE_PNG -DUSE_PTHREAD \
 	 -I../include$(ARCH)  -I../include$(ARCH)/SDL \
 	 -D_GNU_SOURCE=1 -Dmain=SDL_main \
 	 -O4 -ffast-math \
@@ -56,7 +55,7 @@ LDFLAGS = -L../lib$(ARCH)
 
 LDLIBS =  -lSDL_ttf -lSDL_image -llua -llualib \
 	  -lGLU32 -lopenGL32 \
-	  -lmingw32 -lSDLmain -lSDL -mwindows  -lwinmm -ldxguid \
+	  -lmingw32 -lSDLmain -lSDL -lpng -mwindows  -lwinmm -ldxguid \
 	  -lpthread
 
 INSTALL=cp

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ miscdir=@datadir@/gravit/data
 spawndir=@datadir@/gravit/spawn
 
 bin_PROGRAMS=gravit
-gravit_SOURCES=color.c command.c command.h config.c console.c font.c font.h fps.c frame-ot.c frame-pp.c frame.c gfx.c gravit.h input.c main.c osd.c sdlk.h spawn.c texture.c timer.c tool.c
+gravit_SOURCES=color.c command.c command.h config.c console.c font.c font.h fps.c frame-ot.c frame-pp.c frame-pp_sse.c frame.c gfx.c gravit.h input.c main.c osd.c sdlk.h spawn.c texture.c timer.c tool.c png_save.c
 EXTRA_DIST=README COPYING gravit.cfg demo.cfg screensaver.cfg ChangeLog Makefile.old $(shell ls data/*) $(shell ls spawn/*)
 sysconf_DATA = gravit.cfg screensaver.cfg
 misc_DATA = $(shell ls data/*)
@@ -21,5 +21,5 @@ EXTRA_gravit_SOURCES =
 gravit_LDADD =
 endif
 
-AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DDATA_DIR=\"$(datadir)\" -g -Wall $(LUA_CFLAGS)
+AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" -DDATA_DIR=\"$(datadir)\" -g -O4 -Wall $(LUA_CFLAGS)
 

--- a/Makefile.old
+++ b/Makefile.old
@@ -1,8 +1,8 @@
 FINAL = gravit
-OBJS = 	main.o font.o frame.o frame-pp.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o lua.o
+OBJS = 	main.o font.o frame.o frame-pp.o frame-pp_sse.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o lua.o png_save.o
 
-CFLAGS = -g -O4 -Wall `sdl-config --cflags` `lua-config --include` -Wall -DWITH_LUA
-LDFLAGS = -L/usr/X11R6/lib -lGL -lGLU -lSDL_ttf -lSDL_image `sdl-config --libs` -llualib50 `lua-config --libs`
+CFLAGS = -g -O2 -Wall `sdl-config --cflags` `lua-config --include` -Wall -DWITH_LUA -DHAVE_LUA -DHAVE_SSE -DHAVE_PNG
+LDFLAGS = -L/usr/X11R6/lib -lGL -lGLU -lSDL_ttf -lSDL_image `sdl-config --libs` -llualib50 `lua-config --libs` -lpng
 INSTALL=/bin/install
 
 all: final

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,9 +1,9 @@
 FINAL = gravit
-OBJS = 	main.o font.o frame.o frame-pp.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o
+OBJS = 	main.o font.o frame.o frame-pp.o frame-pp_sse.o frame-ot.o gfx.o input.o console.o osd.o spawn.o tool.o command.o fps.o color.o config.o timer.o png_save.o
 
 CFLAGS = -g -O4 -Wall `sdl-config --cflags` 
 #ALDFLAGS = -L/usr/X11R6/lib -lGL -lGLU -lSDL_ttf -lSDL_image `sdl-config --libs` 
-LDFLAGS = -L/usr/X11R6/lib -framework OpenGL -lSDL_ttf -lSDL_image `sdl-config --libs` 
+LDFLAGS = -L/usr/X11R6/lib -framework OpenGL -lSDL_ttf -lSDL_image `sdl-config --libs` -lpng
 INSTALL=/bin/install
 
 all: final

--- a/command.c
+++ b/command.c
@@ -485,12 +485,6 @@ restart:
                     needrestart = 1;
                 }
 
-                if (pd2->mass == 0) {
-                    conAdd(LERR, "Particle %i has no mass", j);
-                    pd2->mass = 1;
-                    needrestart = 1;
-                }
-
                 VectorSub(p1->pos, p2->pos, diff);
 #define MIN_STEP 0.001
                 if (fabs(diff[0]) < MIN_STEP && fabs(diff[1]) < MIN_STEP && fabs(diff[2]) < MIN_STEP) {
@@ -911,7 +905,11 @@ void cmdScreenshot(char *arg) {
 
         FILE *fp;
 
+#ifdef HAVE_PNG
+        fileName = va("%s/gravit%05u.png", SCREENSHOT_PATH, view.screenshotIndex++);
+#else
         fileName = va("%s/gravit%05u.bmp", SCREENSHOT_PATH, view.screenshotIndex++);
+#endif
         fp = fopen(fileName, "rb");
 
         if (!fp)
@@ -921,7 +919,11 @@ void cmdScreenshot(char *arg) {
 
     }
 
+#ifdef HAVE_PNG
+    png_save_surface(fileName, sdlSurfNormal);
+#else
     SDL_SaveBMP(sdlSurfNormal, fileName);
+#endif
 
     SDL_FreeSurface(sdlSurfUpsideDown);
     SDL_FreeSurface(sdlSurfNormal);

--- a/frame-ot.c
+++ b/frame-ot.c
@@ -125,7 +125,7 @@ void otBranchNodeCorner(node_t *n, int br, float *min, float *max) {
         return;
 
     view.recordNodes++;
-    n->b[br] = _aligned_malloc(sizeof(node_t), 16);
+    n->b[br] = malloc(sizeof(node_t));
     b = (node_t *)n->b[br];
 
     memset(b, 0, sizeof(node_t));
@@ -297,7 +297,7 @@ void otMakeTree() {
     node_t *n;
 
     // make root node
-    r = _aligned_malloc(sizeof(node_t), 16);
+    r = malloc(sizeof(node_t));
     memset(r, 0, sizeof(node_t));
     view.recordNodes = 1;
 
@@ -334,7 +334,7 @@ void otFreeTreeRecursive(node_t *n) {
 
     }
 
-    _aligned_free(n);
+    free(n);
     view.recordNodes--;
 
 }

--- a/frame-pp_sse.c
+++ b/frame-pp_sse.c
@@ -1,0 +1,265 @@
+/*
+
+Gravit - A gravity simulator
+Copyright 2003-2005 Gerald Kaszuba
+
+Gravit is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Gravit is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Gravit; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*/
+
+#include "gravit.h"
+
+#ifdef _OPENMP
+// experimental OMP support
+#include <omp.h> // VC has to include this header to build the correct manifest to find vcom.dll or vcompd.dll
+#endif
+
+
+// mm_malloc gives back aligned blocks
+//#include <mm_malloc.h>
+#include <malloc.h>
+
+// __restrict__ tell the compiler that two pointer will not point to the same location
+// if your compiler complains, just remove __restrict__
+
+#ifdef _MSC_VER
+//#define __restrict__ __restrict
+//#define __restrict__ __declspec(restrict)
+// problems with openMP
+#define __restrict__
+#endif
+
+
+typedef struct {
+  float * __restrict__ x;
+  float * __restrict__ y;
+  float * __restrict__ z;
+  float * __restrict__ mass;
+} particle_vectors;
+
+typedef struct {
+  float * __restrict__ x;
+  float * __restrict__ y;
+  float * __restrict__ z;
+} vel_vectors;
+
+
+
+#include "sse_functions.h"
+
+
+  /*  Optimizations:
+      ===============
+      * before processing, copy particle data to vector-friendly arrays
+      * delay multiplication with G
+      * after processing, write back results
+  */
+
+
+#define MIN_STEP2 0.05f
+//static const __m128 vmin_step2 ALIGNED = _mm_set1_ps(MIN_STEP2);
+static const __v128 vmin_step2 = _mm_init1_ps(MIN_STEP2);
+
+static void do_processFramePP(particle_vectors pos, vel_vectors vel, 
+                              int start, int amount) {
+     int i;
+
+    // apply gravity to every specified velocity
+    #ifdef _OPENMP
+    #pragma omp parallel for schedule(dynamic, 256)
+    #endif
+    for (i = start; i < amount; i++) {
+        __v128 p1_vpos_x ;
+        __v128 p1_vpos_y ;
+        __v128 p1_vpos_z ;
+        __v128 p1_vmass  ;
+
+        __v128 p1_vvel_x  = _mm_init1_ps(0.0f);
+        __v128 p1_vvel_y  = _mm_init1_ps(0.0f);
+        __v128 p1_vvel_z  = _mm_init1_ps(0.0f);
+
+        //VectorNew(p1_pos);
+        //VectorNew(p1_vel);
+	//VectorZero(p1_vel);
+
+        float p1_pos_x;
+        float p1_pos_y;
+        float p1_pos_z;
+        float p1_mass;
+
+        float p1_vel_x = 0.0f;
+        float p1_vel_y = 0.0f;
+        float p1_vel_z = 0.0f;
+
+
+        int j;
+	int vector_limit;
+       	vector_limit = (i / 4) * 4;  // round down to value divisible by 4
+
+	p1_vpos_x = _mm_set1_ps(pos.x[i]);
+	p1_vpos_y = _mm_set1_ps(pos.y[i]);
+	p1_vpos_z = _mm_set1_ps(pos.z[i]);
+	p1_vmass  = _mm_set1_ps(pos.mass[i]);
+
+
+	// SSE loop - four particles at once
+        for (j = 0; j < vector_limit; j += 4) {
+	    __v128 dv_vx ;
+	    __v128 dv_vy ;
+	    __v128 dv_vz ;
+	    __v128 vInvSqDist;
+	    __v128 vforce;
+
+            dv_vx = p1_vpos_x - _mm_load_ps(&(pos.x[j]));
+            dv_vy = p1_vpos_y - _mm_load_ps(&(pos.y[j]));
+            dv_vz = p1_vpos_z - _mm_load_ps(&(pos.z[j]));
+
+            // get distance^2 between the two
+	    vInvSqDist  = dv_vx * dv_vx;
+	    vInvSqDist += dv_vy * dv_vy;
+	    vInvSqDist += dv_vz * dv_vz;
+	    vInvSqDist += vmin_step2;
+
+            vforce = p1_vmass * _mm_load_ps(&(pos.mass[j])) * newtonrapson_rcp(vInvSqDist);
+
+            // sum of accelerations for p1
+            p1_vvel_x += dv_vx * vforce;
+            p1_vvel_y += dv_vy * vforce;
+            p1_vvel_z += dv_vz * vforce;
+
+            // add acceleration for p2 (with negative sign, as the direction is inverted)
+            *(__v4sf *) &(vel.x[j]) -= dv_vx * vforce;
+            *(__v4sf *) &(vel.y[j]) -= dv_vy * vforce;
+            *(__v4sf *) &(vel.z[j]) -= dv_vz * vforce;
+
+        }
+
+
+	// cache p1 data
+	p1_pos_x = pos.x[i];
+	p1_pos_y = pos.y[i];
+	p1_pos_z = pos.z[i];
+	p1_mass   = pos.mass[i];
+
+	// copy vector results  to single floats
+	p1_vel_x = _vector4_sum(p1_vvel_x);
+	p1_vel_y = _vector4_sum(p1_vvel_y);
+	p1_vel_z = _vector4_sum(p1_vvel_z);
+
+
+	// do the remaining particles without SSE
+        for (j = vector_limit; j < i; j++) {
+	    VectorNew(dv);
+	    float inverseSquareDistance;
+	    float force;
+
+            dv[0] = p1_pos_x - pos.x[j];
+            dv[1] = p1_pos_y - pos.y[j];
+            dv[2] = p1_pos_z - pos.z[j];
+
+            // get distance^2 between the two
+	    inverseSquareDistance  = dv[0] * dv[0];
+	    inverseSquareDistance += dv[1] * dv[1];
+	    inverseSquareDistance += dv[2] * dv[2];
+	    inverseSquareDistance +=  + MIN_STEP2;
+
+            force = p1_mass * pos.mass[j] / inverseSquareDistance;
+
+            // sum of accelerations for p1
+            p1_vel_x += dv[0] * force;
+            p1_vel_y += dv[1] * force;
+            p1_vel_z += dv[2] * force;
+
+            // add acceleration for p2 (with negative sign, as the direction is inverted)
+            vel.x[j] -= dv[0] * force;
+            vel.y[j] -= dv[1] * force;
+            vel.z[j] -= dv[2] * force;
+
+        }
+
+
+        // write back buffered acceleration of p1
+        vel.x[i] += p1_vel_x;
+        vel.y[i] += p1_vel_y;
+        vel.z[i] += p1_vel_z;
+
+    }
+
+}
+
+
+
+void processFramePP(int start, int amount) {
+    particle_vectors pos;
+    vel_vectors vel;
+    particle_t *framebase = state.particleHistory + state.particleCount*state.frame;
+
+    int i;
+    int particles_max;
+    particles_max = state.particleCount;
+
+
+    // create arrays, aligned to 16 bytes
+
+    pos.x = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.y = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.z = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.mass = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    //memset(pos.x, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.y, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.z, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.mass, 0, sizeof(float) * (particles_max + 16));
+    vel.x = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    vel.y = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    vel.z = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    memset(vel.x, 0, sizeof(float) * (particles_max + 16));
+    memset(vel.y, 0, sizeof(float) * (particles_max + 16));
+    memset(vel.z, 0, sizeof(float) * (particles_max + 16));
+
+
+    // copy frame data to vector-friendly arrays
+    for (i=0; i<particles_max; i++)
+	{
+	  pos.x[i] = framebase[i].pos[0];
+	  pos.y[i] = framebase[i].pos[1];
+	  pos.z[i] = framebase[i].pos[2];
+	  pos.mass[i] = state.particleDetail[i].mass;
+    }
+
+
+    // calculate new accelerations
+    do_processFramePP(pos, vel, start, amount);
+
+
+    // write back results
+    for (i=0; i<particles_max; i++)
+    {
+	  framebase[i].vel[0] += vel.x[i] * state.g;
+	  framebase[i].vel[1] += vel.y[i] * state.g;
+	  framebase[i].vel[2] += vel.z[i] * state.g;
+    }
+
+
+    // clean up
+    _mm_free(pos.x);
+    _mm_free(pos.y);
+    _mm_free(pos.z);
+    _mm_free(pos.mass);
+
+    _mm_free(vel.x);
+    _mm_free(vel.y);
+    _mm_free(vel.z);
+
+}

--- a/frame.c
+++ b/frame.c
@@ -37,7 +37,7 @@ int initFrame() {
     cleanMemory();
 
 //	conAdd(LERR, "Allocating %i bytes", FRAMESIZE * state.historyFrames);
-    state.particleHistory = _aligned_malloc(FRAMESIZE * state.historyFrames, 16);
+    state.particleHistory = malloc(FRAMESIZE * state.historyFrames);
 
     if (!state.particleHistory) {
 
@@ -53,7 +53,7 @@ int initFrame() {
     if (!state.particleDetail) {
 
         conAdd(LNORM, "Could not allocate %i bytes of memory for particleDetail", FRAMEDETAILSIZE);
-        _aligned_free(state.particleHistory);
+        free(state.particleHistory);
         state.memoryAllocated = 0;
         return 0;
 

--- a/frame.c
+++ b/frame.c
@@ -23,7 +23,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #ifdef _OPENMP
 #include <omp.h>
+
+#pragma message("OpenMP optimized multithreading enabled.")
+#else
+#if (!defined(WIN32) || defined(USE_PTHREAD))
+#pragma message("pthreads multithreading enabled.")
+#else
+#pragma message( __FILE__ " : warning : multithreading not availeable.")
 #endif
+#endif
+
 
 int initFrame() {
 
@@ -37,7 +46,7 @@ int initFrame() {
     cleanMemory();
 
 //	conAdd(LERR, "Allocating %i bytes", FRAMESIZE * state.historyFrames);
-    state.particleHistory = malloc(FRAMESIZE * state.historyFrames);
+    state.particleHistory = calloc(FRAMESIZE, state.historyFrames);
 
     if (!state.particleHistory) {
 
@@ -92,7 +101,11 @@ void processFrameThread(int thread) {
 #if NBODY_METHOD == METHOD_OT
     processFrameOT(sliceStart, sliceEnd);
 #else
+#ifdef HAVE_SSE
+    processFramePP_SSE(sliceStart, sliceEnd);
+#else
     processFramePP(sliceStart, sliceEnd);
+#endif
 #endif
     
 }

--- a/gravit.h
+++ b/gravit.h
@@ -197,6 +197,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define VectorAdd(a,b,c) { c[0] = a[0] + b[0]; c[1] = a[1] + b[1]; c[2] = a[2] + b[2]; }
 #define VectorSub(a,b,c) { c[0] = a[0] - b[0]; c[1] = a[1] - b[1]; c[2] = a[2] - b[2]; }
 #define VectorMultiply(a, b, c) { c[0] = a[0] * b; c[1] = a[1] * b; c[2] = a[2] * b; }
+#define VectorMultiplyAdd(a, b, c) { c[0] += a[0] * b; c[1] += a[1] * b; c[2] += a[2] * b; }
 #define VectorDivide(a, b, c) { c[0] = a[0] / b; c[1] = a[1] / b; c[2] = a[2] / b; }
 #define VectorZero(x) { x[0] = 0; x[1] = 0; x[2] = 0; }
 
@@ -223,16 +224,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define Uint8 unsigned char
 #endif
 
-#ifndef WIN32
-//#define _aligned_malloc(a,b) malloc(a)
-//#define _aligned_free(a) free(a)
-#else
+#ifdef WIN32
 #include <malloc.h>
 #include <memory.h>
 #endif
 
-//#define _aligned_malloc(a,b) malloc(a)
-//#define _aligned_free(a) free(a)
 
 #define CONSOLE_HISTORY 10
 #define CONSOLE_LENGTH 255
@@ -610,6 +606,10 @@ char *findFile(char *file); // finds a file in gravit's search path
 int fileExists(char *file); // sees if a file is openable
 int checkHomePath();
 
+// png_save.c
+extern int png_save_surface(char *filename, SDL_Surface *surf);
+
+
 // spawn.c
 extern spawnVars_t spawnVars;
 int pickPositions();
@@ -667,6 +667,9 @@ void processCollisions();
 
 // frame-pp.c
 void processFramePP(int s, int n);
+
+// frame-pp_sse.c
+void processFramePP_SSE(int s, int n);
 
 // frame-ot.c
 typedef struct node_s {

--- a/gravit.h
+++ b/gravit.h
@@ -224,12 +224,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #endif
 
 #ifndef WIN32
-//#define _aligned_malloc(a,b) malloc(a)
-//#define _aligned_free(a) free(a)
-#endif
-
 #define _aligned_malloc(a,b) malloc(a)
 #define _aligned_free(a) free(a)
+#else
+#include <malloc.h>
+#include <memory.h>
+#endif
+
+//#define _aligned_malloc(a,b) malloc(a)
+//#define _aligned_free(a) free(a)
 
 #define CONSOLE_HISTORY 10
 #define CONSOLE_LENGTH 255

--- a/gravit.h
+++ b/gravit.h
@@ -224,8 +224,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #endif
 
 #ifndef WIN32
-#define _aligned_malloc(a,b) malloc(a)
-#define _aligned_free(a) free(a)
+//#define _aligned_malloc(a,b) malloc(a)
+//#define _aligned_free(a) free(a)
 #else
 #include <malloc.h>
 #include <memory.h>

--- a/gravit.vcproj
+++ b/gravit.vcproj
@@ -57,7 +57,7 @@
 				EnableFiberSafeOptimizations="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				StringPooling="true"
 				SmallerTypeCheck="false"
 				RuntimeLibrary="0"
@@ -88,7 +88,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -165,7 +165,7 @@
 				EnableFiberSafeOptimizations="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				StringPooling="true"
 				SmallerTypeCheck="false"
 				RuntimeLibrary="0"
@@ -196,7 +196,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -267,7 +267,7 @@
 				Optimization="0"
 				WholeProgramOptimization="false"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
@@ -296,7 +296,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit-debug.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -369,7 +369,7 @@
 				Optimization="0"
 				WholeProgramOptimization="false"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
@@ -398,7 +398,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit-debug.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -701,6 +701,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\frame-pp_sse.c"
+				>
+			</File>
+			<File
 				RelativePath="frame.c"
 				>
 				<FileConfiguration
@@ -915,6 +919,10 @@
 						PreprocessorDefinitions=""
 					/>
 				</FileConfiguration>
+			</File>
+			<File
+				RelativePath=".\png_save.c"
+				>
 			</File>
 			<File
 				RelativePath="spawn.c"

--- a/gravit_omp.vcproj
+++ b/gravit_omp.vcproj
@@ -57,7 +57,7 @@
 				EnableFiberSafeOptimizations="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				StringPooling="true"
 				SmallerTypeCheck="false"
 				RuntimeLibrary="0"
@@ -88,7 +88,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib vcomp.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib vcomp.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit_omp.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -165,7 +165,7 @@
 				EnableFiberSafeOptimizations="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				StringPooling="true"
 				SmallerTypeCheck="false"
 				RuntimeLibrary="0"
@@ -196,7 +196,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib vcomp.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrt.lib vcomp.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit_omp.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -267,7 +267,7 @@
 				Optimization="0"
 				WholeProgramOptimization="false"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
@@ -297,7 +297,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrtd.lib vcompd.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrtd.lib vcompd.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit-debug_omp.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -370,7 +370,7 @@
 				Optimization="0"
 				WholeProgramOptimization="false"
 				AdditionalIncludeDirectories="../include;../include/SDL"
-				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;HAVE_LUA;HAVE_SSE;HAVE_PNG"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
@@ -400,7 +400,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="odbc32.lib odbccp32.lib Lua+Lib.lib Gdi32.lib Advapi32.lib User32.lib msvcrtd.lib vcompd.lib SDL.lib SDLmain.lib SDL_ttf.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
+				AdditionalDependencies="odbc32.lib odbccp32.lib Lua.lib LuaLib.lib Gdi32.lib Advapi32.lib User32.lib msvcrtd.lib vcompd.lib SDL.lib SDLmain.lib SDL_ttf.lib libpng.lib zlib.lib opengl32.lib glu32.lib SDL_image.lib oldnames.lib"
 				OutputFile="gravit-debug_omp.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -735,6 +735,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath=".\frame-pp_sse.c"
+				>
+			</File>
+			<File
 				RelativePath="frame.c"
 				>
 				<FileConfiguration
@@ -949,6 +953,10 @@
 						PreprocessorDefinitions=""
 					/>
 				</FileConfiguration>
+			</File>
+			<File
+				RelativePath=".\png_save.c"
+				>
 			</File>
 			<File
 				RelativePath="spawn.c"

--- a/lua.c
+++ b/lua.c
@@ -62,8 +62,9 @@ void luaHandleError() {
 
     conAdd(LNORM, "Stack size: %i", lua_gettop(state.lua));
 
-    const char *err = lua_tostring(state.lua, -1);
-    conAdd(LERR, "%s", err);
+    //const char *err = lua_tostring(state.lua, -1);
+    //conAdd(LERR, "%s", err);
+    conAdd(LERR, "%s", lua_tostring(state.lua, -1));
     lua_pop(state.lua, 1);
     
 }
@@ -124,12 +125,13 @@ void luag_TableToVector(lua_State *L, float *v) {
 int luag_load(lua_State *L) {
     
     char *s = (char*)lua_tostring(L, -1);
+    char *f;
     conAdd(1, s);
     lua_pop(L, 1);
     
     s = va("spawn/%s", s);
     
-    char *f = findFile(s);
+    f = findFile(s);
     conAdd(1, f);
     
     luaExecute(findFile(f));
@@ -189,5 +191,7 @@ int luag_log(lua_State *L) {
 
 }
 
+#else
+#pragma message( __FILE__ " : warning : define HAVE_LUA   to enable LUA spawn script support." )
 #endif
 

--- a/main.c
+++ b/main.c
@@ -61,14 +61,14 @@ void cleanMemory() {
 
     if (state.particleHistory) {
 
-        _aligned_free(state.particleHistory);
+        free(state.particleHistory);
         state.particleHistory = 0;
 
     }
 
     if (state.particleDetail) {
 
-        _aligned_free(state.particleDetail);
+        free(state.particleDetail);
         state.particleDetail = 0;
 
     }

--- a/png_save.c
+++ b/png_save.c
@@ -1,0 +1,187 @@
+/* SaveSurf: an example on how to save a SDLSurface in PNG
+   Copyright (C) 2006 Angelo "Encelo" Theodorou
+ 
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+ 
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+  
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 
+   NOTE: 
+ 
+   This program is part of "Mars, Land of No Mercy" SDL examples, 
+   you can find other examples on http://marsnomercy.org
+
+*/
+
+#include "gravit.h"
+
+
+#if HAVE_PNG
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <SDL.h>
+#include <SDL_image.h>
+#include <png.h>
+
+
+static int png_colortype_from_surface(SDL_Surface *surface)
+{
+	int colortype = PNG_COLOR_MASK_COLOR; /* grayscale not supported */
+
+	if (surface->format->palette)
+		colortype |= PNG_COLOR_MASK_PALETTE;
+	else if (surface->format->Amask)
+		colortype |= PNG_COLOR_MASK_ALPHA;
+		
+	return colortype;
+}
+
+void png_user_warn(png_structp ctx, png_const_charp str)
+{
+        conAdd(LNORM, "libpng warning: %s", str);
+}
+
+void png_user_error(png_structp ctx, png_const_charp str)
+{
+        conAdd(LERR, "libpng error: %s", str);
+}
+
+
+
+int png_save_surface(char *filename, SDL_Surface *surf)
+{
+	FILE *fp;
+	png_structp png_ptr;
+	png_infop info_ptr;
+	int i, colortype;
+	png_bytep *row_pointers;
+
+	/* Opening output file */
+	fp = fopen(filename, "wb");
+	if (fp == NULL) {
+		conAdd(LERR, "png_save %s : %s", filename, strerror(errno));
+		return -1;
+	}
+
+	/* Initializing png structures and callbacks */
+	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, 
+		NULL, png_user_error, png_user_warn);
+	if (png_ptr == NULL) {
+		conAdd(LERR, "png_save: png_create_write_struct error!");
+		return -1;
+	}
+
+	info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == NULL) {
+		png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+		conAdd(LERR, "png_save: png_create_info_struct error!");
+		return -1;
+	}
+
+	if (setjmp(png_jmpbuf(png_ptr))) {
+		png_destroy_write_struct(&png_ptr, &info_ptr);
+		fclose(fp);
+		return -1;
+	}
+
+	png_init_io(png_ptr, fp);
+
+	colortype = png_colortype_from_surface(surf);
+	png_set_IHDR(png_ptr, info_ptr, surf->w, surf->h, 8, colortype,	PNG_INTERLACE_NONE, 
+		PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+
+	/* Writing the image */
+	png_write_info(png_ptr, info_ptr);
+	png_set_packing(png_ptr);
+
+	row_pointers = (png_bytep*) malloc(sizeof(png_bytep)*surf->h);
+	for (i = 0; i < surf->h; i++)
+		row_pointers[i] = (png_bytep)(Uint8 *)surf->pixels + i*surf->pitch;
+	png_write_image(png_ptr, row_pointers);
+	png_write_end(png_ptr, info_ptr);
+
+	/* Cleaning out... */
+	free(row_pointers);
+	png_destroy_write_struct(&png_ptr, &info_ptr);
+	fclose(fp);
+
+	return 0;
+}
+
+
+#if 0
+// example 
+// loads a PNG file an into SDL surface, and then writes it back to a PNG file.
+int main(int argc, char **argv)
+{
+	SDL_Surface *input_surf;
+	char *input, *output, *str_ptr;
+	int namelen;
+
+
+	/* Parsing shell parameters */
+	if (argc == 3) {
+		input = argv[1];
+		output = argv[2];
+	}
+	else if (argc == 2) {
+		input = argv[1];
+		str_ptr = strstr(argv[1], ".");
+		if (str_ptr == NULL)
+			namelen = strlen(argv[1]);
+		else
+			namelen = str_ptr - argv[1];
+		output = (char *)malloc(namelen + 5);
+		strncpy(output, argv[1], namelen);
+		strcat(output, ".png");
+	}
+	else {
+		printf("The correct syntax is: %s input [output]\n", argv[0]);
+		exit(-1);
+	}
+
+	/* Initializing video subsystem */
+	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+		printf("SDL_Init error: %s\n", SDL_GetError());
+		exit (-1);
+	}
+                                      
+	/* Calling SDL_Quit at exit */	
+	atexit(SDL_Quit);
+
+	printf("input file: %s\n", input);
+	printf("output file: %s\n", output);
+
+	/* Opening input and output files */
+	input_surf = IMG_Load(input);
+	if (input_surf == NULL) {
+		printf("IMG_Load error: %s\n", IMG_GetError());
+		exit(-1);
+	}
+
+	if(png_save_surface(output, input_surf) < 0);
+		exit(-1);
+
+	/* Quitting */
+	if (argc == 2)
+		free(output);
+	SDL_Quit();
+
+	return 0;
+}
+#endif
+
+#else
+#warning no PNG support
+#endif

--- a/png_save.c
+++ b/png_save.c
@@ -183,5 +183,5 @@ int main(int argc, char **argv)
 #endif
 
 #else
-#warning no PNG support
+#pragma message( __FILE__ " : warning : define HAVE_PNG  to enable PNG screenshot support." )
 #endif

--- a/spawn/binary-galaxy.gravitspawn
+++ b/spawn/binary-galaxy.gravitspawn
@@ -17,7 +17,7 @@ function spawn()
 	local ballsize1 = randomfloat(500,1000)
 	local ballsize2 = randomfloat(500,1000)
 
-	makegalaxy(v(0,dist,0), v(-vel,0,0), ballsize1, mass1min, mass1max, 0, spawnparticles/2)
-	makegalaxy(v(0,-dist,0), v(vel,0,0), ballsize2, mass2min, mass2max, spawnparticles/2, spawnparticles/2)
+	makegalaxy(v(0,dist,0), v(-vel,0,0), ballsize1, mass1min, mass1max, 0, math.floor(spawnparticles/2))
+	makegalaxy(v(0,-dist,0), v(vel,0,0), ballsize2, mass2min, mass2max, math.floor(spawnparticles/2), spawnparticles - math.floor(spawnparticles/2))
 	
 end

--- a/spawn/many-galaxy.gravitspawn
+++ b/spawn/many-galaxy.gravitspawn
@@ -16,8 +16,12 @@ function spawn()
 		local rad = randomfloat(50, 1000)
 		local massmin = randomfloat(10,1000)
 		local massmax = randomfloat(10,1000)
-		local particlestart = spawnparticles/galaxies*i
-		local particlecount = spawnparticles/galaxies
+		local particlestart = math.floor(spawnparticles/galaxies)*i
+		local particlecount = math.floor(spawnparticles/galaxies)
+		if (i == galaxies-1) then 
+		      particlecount = spawnparticles - particlestart
+		end
+
 		makegalaxy(pos, vel, rad, massmin, massmax, particlestart, particlecount)
 	end
 end

--- a/spawn/negative-collision.gravitspawn
+++ b/spawn/negative-collision.gravitspawn
@@ -14,7 +14,7 @@ function spawn()
 	masses = 100
 	range = 2000
 	speed = 5
-	makegalaxy(v(-range,0,0), v(speed,0,0), randomfloat(10,1000), 0, masses, 0, spawnparticles/2)
-	makegalaxy(v(range,0,0), v(-speed,0,0), randomfloat(10,1000), 0, -masses, spawnparticles/2, spawnparticles/2)
+	makegalaxy(v(-range,0,0), v(speed,0,0), randomfloat(10,1000), 0, masses, 0, math.floor(spawnparticles/2))
+	makegalaxy(v(range,0,0), v(-speed,0,0), randomfloat(10,1000), 0, -masses, math.floor(spawnparticles/2), spawnparticles - math.floor(spawnparticles/2))
 	
 end

--- a/spawn/surround.gravitspawn
+++ b/spawn/surround.gravitspawn
@@ -8,9 +8,10 @@ end
 
 function spawn()
 
-	makegalaxy(v(0,0,0), v(0,0,0), randomfloat(1,1000), randomfloat(1, 1000), 0, 0, spawnparticles/2)
+        makegalaxy(v(0,0,0), v(0,0,0), randomfloat(1,1000), randomfloat(1, 1000), 0, 0, math.floor(spawnparticles/2))
     
-    m = randomfloat(1, 2000)
-	makeball(v(0,0,0), v(0,0,0), randomfloat(1000,10000), 0, randomfloat(1, m), spawnparticles/2, spawnparticles/2)
+        m = randomfloat(1, 2000)
+        makeball(v(0,0,0), v(0,0,0), randomfloat(1000,10000), 0, randomfloat(1, m), 
+                 math.floor(spawnparticles/2), spawnparticles - math.floor(spawnparticles/2))
 	
 end

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -1,0 +1,69 @@
+
+
+#ifdef _MSC_VER
+// microsoft SSE -- not tested yet
+#include <xmmintrin.h>
+#define __v128 __m128
+#else
+// gcc SSE 
+#include <x86intrin.h>
+#define ALIGNED __attribute__((aligned (16))) 
+
+typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
+
+#define _mm_init1_ps(f) {f, f, f, f}
+
+#endif
+
+
+
+// aux. constants
+static const __v128 _half4 = { .5f, .5f, .5f, .5f}; 
+static const __v128 _three4= { 3.f, 3.f, 3.f, 3.f}; 
+static const __v128 _two4  = { 2.f, 2.f, 2.f, 2.f}; 
+
+
+// SSE fast inverse square root
+// accuracy: approx. 22bit 
+static inline __v128 __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot)) 
+newtonrapson_rsqrt4( const __v128 v ) 
+{
+  //  x = rsqrt_approx(v);
+  //  x' = 0.5 * x * (3 - v*x*x);
+
+  __v128 approx = _mm_rsqrt_ps( v );
+  // one newton-rapson step to improve accuracy
+  return _mm_mul_ps(_mm_mul_ps(_half4, approx), 
+		               _mm_sub_ps(_three4, 
+				          _mm_mul_ps(_mm_mul_ps(v, approx), approx) ) );
+}
+
+
+// SSE fast inverse
+
+static inline __v128 __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot)) 
+newtonrapson_rcp(const __v128 a)
+{
+  //  x = reciprocal_approx(c);
+  //  x' = x * (2 - x * a); --> x' = 2x - x( x*a) = (x+x) - x (x*a)
+
+  __v128 r = _mm_rcp_ps(a);
+  return _mm_sub_ps(_mm_add_ps(r, r), _mm_mul_ps(_mm_mul_ps(r, a), r));
+}
+
+
+
+// SSE: sum of all four elements of a vector
+
+static inline float  __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot))
+_vector4_sum(const __v128 b)
+{ 
+  __v128 a;
+
+  a = _mm_shuffle_ps(b,b, 0b00110001);                                       // 1->0, 3->2; 
+  a = _mm_add_ps(a, b);                                                      // 0+1, 1+0, 2+3, 3+2
+  return(_mm_cvtss_f32(_mm_add_ps(a, _mm_shuffle_ps(a,a, 0b00000010))));     // 2->0
+                                                                             // 0 = 1 + 0 + 3 + 2
+}
+
+

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -2,17 +2,24 @@
 
 #ifndef __GNUC__
 /* ******************************************************************* */
+// no GCC
 #include <xmmintrin.h>
+#define __v128 __m128
+#define _mm_init1_ps(f) {f, f, f, f}
 
 #ifdef _MSC_VER
 // microsoft specific
+
+//#if (defined(_M_IX86_FP) && (_M_IX86_FP >= 1)) || defined(_M_X64) || defined(_M_AMD64)
+//#define __SSE__
+//#define __SSE2__
+//#endif
+
 #define ALWAYS_INLINE(ret_type) static __forceinline ret_type 
+
 #else
 #define ALWAYS_INLINE(ret_type) static inline ret_type 
 #endif
-
-#define __v128 __m128
-#define _mm_init1_ps(f) {f, f, f, f}
 
 #else
 /* ******************************************************************* */

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -1,68 +1,132 @@
 
 
-#ifdef _MSC_VER
-// microsoft SSE -- not tested yet
+#ifndef __GNUC__
+/* ******************************************************************* */
 #include <xmmintrin.h>
-#define __v128 __m128
+
+#ifdef _MSC_VER
+// microsoft specific
+#define ALWAYS_INLINE(ret_type) static __forceinline ret_type 
 #else
-// gcc SSE 
-#include <x86intrin.h>
-#define ALIGNED __attribute__((aligned (16))) 
+#define ALWAYS_INLINE(ret_type) static inline ret_type 
+#endif
 
-typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
-
+#define __v128 __m128
 #define _mm_init1_ps(f) {f, f, f, f}
 
+#else
+/* ******************************************************************* */
+// use gcc extensions for SSE 
+#include <x86intrin.h>
+#include <mm_malloc.h>
+#define ALIGNED __attribute__((aligned (16))) 
+#define ALWAYS_INLINE(ret_type) static inline ret_type __attribute__((__gnu_inline__, __always_inline__, __artificial__)) 
+
+typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
+#define _mm_init1_ps(f) {f, f, f, f}
 #endif
 
 
+/* ******************************************************************* */
+// Number of Element an SSE operation processes
+#define VECT_SIZE 4
 
+
+/* ******************************************************************* */
+// macros to make the source easier to read
+
+#if 0 && defined(__GNUC__)
+// let GCC do it - slower (unaligned mem. access ??)
+#define LOAD_V4(arr, ind)         ( *((__v128 *) (arr + ind)) )
+#define STORE_V4(arr, ind, value) { *((__v128 *) (arr + ind)) = value ;}
+#define ADD_V4(arr, ind, value) { *((__v128 *) (arr + ind)) += (value) ;}
+#define SUB_V4(arr, ind, value) { *((__v128 *) (arr + ind)) -= (value) ;}
+
+#else
+// use SSE macros
+#define LOAD_V4(arr, ind)          _mm_load_ps((arr + ind))
+#define STORE_V4(arr, ind, value) _mm_store_ps((arr + ind), (value))
+#define ADD_V4(arr, ind, value)   _mm_store_ps((arr + ind), _mm_add_ps( _mm_load_ps((arr + ind)),  (value)))
+#define SUB_V4(arr, ind, value)   _mm_store_ps((arr + ind), _mm_sub_ps( _mm_load_ps((arr + ind)),  (value)))
+#endif
+
+
+/* ******************************************************************* */
+
+#if 0 && defined(__GNUC__)
+// let GCC do it -- slower ..
+#define V_ADD(a, b) ( (a) + (b))
+#define V_SUB(a, b) ( (a) - (b))
+#define V_MUL(a, b) ( (a) * (b))
+#define V_DIV(a, b) ( (a) / (b))
+#define V_INCR(a, b) {a += (b);} 
+#define V_DECR(a, b) {a -= (b);} 
+
+#else
+// use SSE macros .. somehow faster ...
+#define V_ADD(a, b) _mm_add_ps((a), (b))
+#define V_SUB(a, b) _mm_sub_ps((a), (b))
+#define V_MUL(a, b) _mm_mul_ps((a), (b))
+#define V_DIV(a, b) _mm_div_ps((a), (b))
+#define V_INCR(a, b) {a = _mm_add_ps( (a), (b));} 
+#define V_DECR(a, b) {a = _mm_sub_ps( (a), (b));} 
+#endif
+
+
+/* ******************************************************************* */
 // aux. constants
-static const __v128 _half4 = { .5f, .5f, .5f, .5f}; 
-static const __v128 _three4= { 3.f, 3.f, 3.f, 3.f}; 
-static const __v128 _two4  = { 2.f, 2.f, 2.f, 2.f}; 
+static const __v128 _half4 = _mm_init1_ps(.5f); 
+static const __v128 _three4= _mm_init1_ps(3.f); 
+static const __v128 _two4  = _mm_init1_ps(2.f);
 
 
-// SSE fast inverse square root
-// accuracy: approx. 22bit 
-static inline __v128 __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot)) 
-newtonrapson_rsqrt4( const __v128 v ) 
+
+/* ******************************************************************* */
+/* SSE fast inverse square root                                        */
+/*                            ret = 1/sqrt(v)  accuracy: approx. 22bit */
+/* ******************************************************************* */
+
+ALWAYS_INLINE(__v128) newtonrapson_rsqrt4( const __v128 v ) 
 {
   //  x = rsqrt_approx(v);
   //  x' = 0.5 * x * (3 - v*x*x);
 
   __v128 approx = _mm_rsqrt_ps( v );
   // one newton-rapson step to improve accuracy
-  return _mm_mul_ps(_mm_mul_ps(_half4, approx), 
-		               _mm_sub_ps(_three4, 
-				          _mm_mul_ps(_mm_mul_ps(v, approx), approx) ) );
+  return V_MUL( V_MUL(_half4, approx), 
+		               V_SUB(_three4, 
+				          V_MUL( V_MUL(v, approx), approx) ) );
 }
 
 
-// SSE fast inverse
+/* ******************************************************************* */
+/* SSE fast inverse                                                    */
+/*                            ret = 1/v        accuracy: approx. 22bit */
+/* ******************************************************************* */
 
-static inline __v128 __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot)) 
-newtonrapson_rcp(const __v128 a)
+ALWAYS_INLINE(__v128) newtonrapson_rcp(const __v128 v)
 {
-  //  x = reciprocal_approx(c);
-  //  x' = x * (2 - x * a); --> x' = 2x - x( x*a) = (x+x) - x (x*a)
+  //  x = reciprocal_approx(v);
+  //  x' = x * (2 - x * v); --> x' = 2x - x( x*v) = (x+x) - x (x*v)
 
-  __v128 r = _mm_rcp_ps(a);
-  return _mm_sub_ps(_mm_add_ps(r, r), _mm_mul_ps(_mm_mul_ps(r, a), r));
+  __v128 r = _mm_rcp_ps(v);
+  return (V_SUB( V_ADD(r, r), V_MUL( r, V_MUL(r, v))));
 }
 
 
 
-// SSE: sum of all four elements of a vector
+/* ******************************************************************* */
+/* SSE: sum of all four elements of a vector                           */
+/*                           ret = v[0] + v[1] + v[2] + v[3]           */
+/* ******************************************************************* */
 
-static inline float  __attribute__((__gnu_inline__, __always_inline__, __artificial__, hot))
-_vector4_sum(const __v128 b)
+ALWAYS_INLINE(float) _vector4_sum(const __v128 v)
 { 
   __v128 a;
 
-  a = _mm_shuffle_ps(b,b, 0b00110001);                                       // 1->0, 3->2; 
-  a = _mm_add_ps(a, b);                                                      // 0+1, 1+0, 2+3, 3+2
-  return(_mm_cvtss_f32(_mm_add_ps(a, _mm_shuffle_ps(a,a, 0b00000010))));     // 2->0
+  a = _mm_shuffle_ps(v,v, _MM_SHUFFLE(0,3,0,1));                             // 1->0, 3->2; 
+  a = V_ADD(a, v);                                                           // 0+1, 1+0, 2+3, 3+2
+  return(_mm_cvtss_f32(V_ADD(a, _mm_shuffle_ps(a,a, _MM_SHUFFLE(0,0,0,2)))));// 2->0
                                                                              // 0 = 1 + 0 + 3 + 2
 }
 


### PR DESCRIPTION
Hi,
this update contains the following:
- SSE-optimized version of frame-pp.c. On my computer, it gives a 3.5x to 4x speedup
  (for 8000 particles, I get 15fps on my intel core2 laptop).
- I have also added a function to save screenshots in PNG format (from some SDL example code).
- added some warning messages for disabled features (LUA, SSE, PNG); tested with gcc4 and VisualC, but should at least get ignored by other compilers
- Makefile updates : added frame-pp_sse.c and png_save.c to source files; added  -DHAVE_SSE -DHAVE_PNG to cflags.
  
  --> other build files (OSX Xcode; linux autoconf/automake) may need to be updated, too. 

cheers,
   Frank.
