### PR TITLE
Fix for crash when memoryavailable > 2GB (issue #15)

### DIFF
--- a/color.c
+++ b/color.c
@@ -274,7 +274,9 @@ void setColoursByMass() {
 
 void setColours() {
 
-    switch (view.particleColourMode) {
+	if(state.particleHistory == NULL) return;
+
+	switch (view.particleColourMode) {
 
     case CM_MASS:
     default:

--- a/command.c
+++ b/command.c
@@ -411,7 +411,7 @@ cmdSpawnRestartSpawning:
     state.mode = 0;
 
     state.particleCount = state.particlesToSpawn;
-    state.historyFrames = (int)((float)(state.memoryAvailable * 1024 * 1024) / FRAMESIZE);
+    state.historyFrames = (unsigned int)(((size_t)state.memoryAvailable * 1024 * 1024) / (size_t)FRAMESIZE);
 
     if (!initFrame()) {
         conAdd(LERR, "Could not init frame");

--- a/command.c
+++ b/command.c
@@ -66,7 +66,7 @@ cmd_t cmd[] = {
     ,{ "spawn",						cmdSpawn,				NULL,						NULL,								NULL }
     ,{ "status",					cmdStatus,				NULL,						NULL,								NULL }
 
-    ,{ "recordingvideorefreshtime",	NULL,					NULL,						&view.recordingVideoRefreshTime,	NULL }
+    ,{ "recordingvideorefreshtime",	NULL,					NULL,						(int *)(&view.recordingVideoRefreshTime),	NULL }
 
     ,{ "screensaver",				NULL,					NULL,						&view.screenSaver,					NULL }
     ,{ "installscreensaver",		cmdInstallScreenSaver,	NULL,						NULL,								NULL }

--- a/frame.c
+++ b/frame.c
@@ -45,23 +45,23 @@ int initFrame() {
 
     cleanMemory();
 
-//	conAdd(LERR, "Allocating %i bytes", FRAMESIZE * state.historyFrames);
+//	conAdd(LERR, "Allocating %u bytes", FRAMESIZE * state.historyFrames);
     state.particleHistory = calloc(FRAMESIZE, state.historyFrames);
 
     if (!state.particleHistory) {
 
-        conAdd(LNORM, "Could not allocate %i bytes of memory for particleHistory", FRAMESIZE * state.historyFrames);
+        conAdd(LNORM, "Could not allocate %lu bytes of memory for particleHistory", (unsigned long)(FRAMESIZE * state.historyFrames));
         return 0;
 
     }
 
     state.memoryAllocated += FRAMESIZE * state.historyFrames;
 
-//	conAdd(LERR, "Allocating %i bytes", FRAMEDETAILSIZE);
+//	conAdd(LERR, "Allocating %u bytes", FRAMEDETAILSIZE);
     state.particleDetail = calloc(sizeof(particleDetail_t),state.particleCount);
     if (!state.particleDetail) {
 
-        conAdd(LNORM, "Could not allocate %i bytes of memory for particleDetail", FRAMEDETAILSIZE);
+        conAdd(LNORM, "Could not allocate %ld bytes of memory for particleDetail", (unsigned long)FRAMEDETAILSIZE);
         free(state.particleHistory);
         state.memoryAllocated = 0;
         return 0;

--- a/gfx.c
+++ b/gfx.c
@@ -214,7 +214,7 @@ gfxInitRetry:
     checkPointSprite();
 
     SDL_ShowCursor(view.showCursor);
-    SDL_EnableUNICODE(1);
+    SDL_EnableUNICODE(SDL_ENABLE);
     SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,SDL_DEFAULT_REPEAT_INTERVAL);
 
     return 1;
@@ -841,11 +841,11 @@ FPglPointParameterfvARB glPointParameterfvARB_ptr;
 
 void checkPointParameters() {
 
-    const char *extList;
+    char *extList;
 
     video.supportPointParameters = 0;
 
-    extList = glGetString(GL_EXTENSIONS);
+    extList = (char *)glGetString(GL_EXTENSIONS);
 
     if (strstr(extList, "GL_ARB_point_parameters") == 0) {
         return;
@@ -863,11 +863,11 @@ void checkPointParameters() {
 
 void checkPointSprite() {
 
-    const char *extList;
+    char *extList;
 
     video.supportPointSprite = 0;
 
-    extList = glGetString(GL_EXTENSIONS);
+    extList = (char *)glGetString(GL_EXTENSIONS);
 
     if (strstr(extList, "GL_ARB_point_sprite") == 0)
         return;

--- a/gravit.h
+++ b/gravit.h
@@ -382,7 +382,7 @@ typedef struct state_s {
 
     int particlesToSpawn;
 
-    unsigned int memoryAllocated;
+    size_t memoryAllocated;
 
     int lastSave;	// last frame saved
     int autoSave;	// auto save every n frames. 0 for off.
@@ -592,8 +592,8 @@ int commandLineRead(int argc, char *argv[]);
 // tool.c
 char * va( char *format, ... );
 int gfxPowerOfTwo(int input);
-int LoadMemoryDump(char *fileName, unsigned char *d, unsigned int size);
-int SaveMemoryDump(char *FileName, unsigned char *d, unsigned int total);
+int LoadMemoryDump(char *fileName, unsigned char *d, size_t size);
+int SaveMemoryDump(char *FileName, unsigned char *d, size_t total);
 Uint32 getMS();
 void setTitle(char *state);
 int mymkdir(const char *path);

--- a/input.c
+++ b/input.c
@@ -161,6 +161,11 @@ int processKeys() {
                 view.consoleMode = (!view.consoleMode)?1:0;
                 break;
 
+            case SDLK_CARET:
+            case SDLK_1:
+                view.consoleMode = 1;
+                break;
+
             case SDLK_t:
                 if (++view.drawTree == 3)
                     view.drawTree = 0;

--- a/tool.c
+++ b/tool.c
@@ -69,11 +69,13 @@ int gfxPowerOfTwo(int input) {
 
 }
 
-int LoadMemoryDump(char *fileName, unsigned char *d, unsigned int size) {
+//tool.c(96) : warning C4267: '=' : conversion from 'size_t' to 'unsigned int', possible loss of data
+// make p, pos, size, amountToRead become size_t
+int LoadMemoryDump(char *fileName, unsigned char *d, size_t size) {
 
     FILE *fp;
-    unsigned int i, pos, p, amountToRead;
-    unsigned int chunkMax = FILE_CHUNK_SIZE;
+    size_t i, pos, p, amountToRead;
+    size_t chunkMax = FILE_CHUNK_SIZE;
 
     fp = fopen(fileName, "rb");
     if (!fp) {
@@ -131,10 +133,12 @@ int LoadMemoryDump(char *fileName, unsigned char *d, unsigned int size) {
     return 1;
 }
 
-int SaveMemoryDump(char *fileName, unsigned char *d, unsigned int total) {
+//tool.c(96) : warning C4267: '=' : conversion from 'size_t' to 'unsigned int', possible loss of data
+// make p, pos, size, amountToRead become size_t
+int SaveMemoryDump(char *fileName, unsigned char *d, size_t total) {
 
     FILE *fp;
-    unsigned int written, p, write;
+    size_t written, p, write;
 
     fp = fopen(fileName, "wb");
     if (!fp) {
@@ -161,7 +165,7 @@ int SaveMemoryDump(char *fileName, unsigned char *d, unsigned int total) {
 
     fclose(fp);
 
-    conAdd(LLOW, "written %u bytes to %s", written, fileName);
+    conAdd(LLOW, "written %lu bytes to %s", (unsigned long)written, fileName);
 
     return 1;
 


### PR DESCRIPTION
The basic problem is that >2GB creates an overflow on variables of type int, so we must use size_t instead.

On Linux 64bit, the fix seems to work. 
On Windows (even 64bit), gravit shows an error that it could not allocate memory, and exits. The reason is that WinDos malloc() just returns NULL when asking for single blocks >2GB.
