### PR TITLE
frame-pp_vector for auto-vectorizing compilers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,8 @@ EXTRA_gravit_SOURCES += lua.c
 gravit_LDADD += lua.o $(LUA_LIBS)
 endif
 
-AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)/\" -DDATA_DIR=\"$(datadir)/\" -O3 -Wall $(LUA_CFLAGS)
+#AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)/\" -DDATA_DIR=\"$(datadir)/\" -O3 -Wall $(LUA_CFLAGS)
+AM_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)/\" -DDATA_DIR=\"$(datadir)/\" $(LUA_CFLAGS)
 
 
 # Rule to build windows resources

--- a/acinclude/ax_func_posix_memalign.m4
+++ b/acinclude/ax_func_posix_memalign.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_func_posix_memalign.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_FUNC_POSIX_MEMALIGN
+#
+# DESCRIPTION
+#
+#   Some versions of posix_memalign (notably glibc 2.2.5) incorrectly apply
+#   their power-of-two check to the size argument, not the alignment
+#   argument. AX_FUNC_POSIX_MEMALIGN defines HAVE_POSIX_MEMALIGN if the
+#   power-of-two check is correctly applied to the alignment argument.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Scott Pakin <pakin@uiuc.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
+[AC_CACHE_CHECK([for working posix_memalign],
+  [ax_cv_func_posix_memalign_works],
+  [AC_TRY_RUN([
+#include <stdlib.h>
+
+int
+main ()
+{
+  void *buffer;
+
+  /* Some versions of glibc incorrectly perform the alignment check on
+   * the size word. */
+  exit (posix_memalign (&buffer, sizeof(void *), 123) != 0);
+}
+    ],
+    [ax_cv_func_posix_memalign_works=yes],
+    [ax_cv_func_posix_memalign_works=no],
+    [ax_cv_func_posix_memalign_works=no])])
+if test "$ax_cv_func_posix_memalign_works" = "yes" ; then
+  AC_DEFINE([HAVE_POSIX_MEMALIGN], [1],
+    [Define to 1 if `posix_memalign' works.])
+fi
+])

--- a/configure.in
+++ b/configure.in
@@ -120,6 +120,15 @@ AC_FUNC_STAT
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([atexit floor ftime memset mkdir pow select sqrt strchr strdup strerror strstr])
 
+# check for functions to do aligned malloc
+AC_CHECK_HEADERS([intrin.h x86intrin.h xmmintrin.h malloc.h memory.h])
+AC_CHECK_FUNCS([memalign _mm_malloc _mm_free _aligned_malloc __mingw_aligned_malloc])
+# AC_CHECK_FUNCS([posix_memalign])
+AX_FUNC_POSIX_MEMALIGN
+if test "$ax_cv_func_posix_memalign_works" = "yes" ; then
+   AC_DEFINE([HAVE_WORKING_POSIX_MEMALIGN], [1], [use `posix_memalign' instead of memalign])
+fi
+
 
 # check for windres (windows ressource compiler)
 if test -z "$host_alias"; then

--- a/configure.in
+++ b/configure.in
@@ -6,6 +6,12 @@
 # -------------
 # * nothing ;-)
 #
+# Changes (FrMo, Sept 2011):
+# -------------
+# * better linux support
+# * silent build
+# * try some compiler-specific optimization flags (gcc, intel icc, open64)
+#
 # Changes (FrMo, Aug 2011):
 # -------------
 # * minor updates needed for newer autoconf versions
@@ -31,23 +37,26 @@ AC_CANONICAL_HOST
 
 dnl Setup for automake
 AM_INIT_AUTOMAKE(gravit, 0.5.2)
+#Enable quiet compiles on automake 1.11.
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+# set default optimization flags
+# use "-Wall -O2 -g" if you want to debug
+: ${CFLAGS="-Wall -O3"}
 # Checks for programs.
 AC_PROG_CC
+AC_LANG_C
 AC_EXEEXT
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-
-AC_PATH_XTRA
-
-CPPFLAGS="$CPPFLAGS $X_CFLAGS"
-LIBS="$LIBS $X_LIBS"
-
+AX_COMPILER_VENDOR
 
 # check for OpenMP support
-AX_OPENMP
+#AX_OPENMP
+AC_OPENMP
 AC_CHECK_HEADERS([omp.h],[
 	CFLAGS="$CFLAGS $OPENMP_CFLAGS"
+	CPPFLAGS="$CPPFLAGS $OPENMP_CFLAGS"
 	LDFLAGS="$LDFLAGS $OPENMP_CFLAGS"
      ])
 
@@ -55,15 +64,36 @@ AC_CHECK_HEADERS([omp.h],[
 # if SSE is supported, HAVE_SSE will be set
 AX_EXT
 CFLAGS="$CFLAGS $SIMD_FLAGS"
-LDFLAGS="$LDFLAGS $SIMD_FLAGS"
+LDFLAGS="$SIMD_FLAGS $LDFLAGS"
+
+# try to add compiler-specific optimization flags
+if test x"$ax_cv_c_compiler_vendor" = x"intel"; then
+   #check for intel (icc) style flags
+   AX_CHECK_COMPILE_FLAG(-ipo, CFLAGS="$CFLAGS -O3 -ipo")
+   AX_CHECK_COMPILE_FLAG(-parallel, CFLAGS="$CFLAGS -parallel")
+   AX_CHECK_COMPILE_FLAG(-fomit-frame-pointer, CFLAGS="$CFLAGS -fomit-frame-pointer")
+   AX_CHECK_COMPILE_FLAG(-no-prec-div, CFLAGS="$CFLAGS -no-prec-div")
+   AX_CHECK_COMPILE_FLAG(-static-intel, CFLAGS="$CFLAGS -static-intel")
+   #only for intel core i3/i5/i7 and newer
+   #AX_CHECK_COMPILE_FLAG(-xSSE4.1, CFLAGS="$CFLAGS -xSSE4.1")
+   #AX_CHECK_COMPILE_FLAG(-xSSE4.2, CFLAGS="$CFLAGS -xSSE4.2")
+else
+   #check for gcc-style optimization flags
+   AX_CHECK_COMPILE_FLAG(-Ofast, CFLAGS="$CFLAGS -Ofast" LDFLAGS="$LDFLAGS -Ofast")
+   AX_CHECK_COMPILE_FLAG(-fomit-frame-pointer, CFLAGS="$CFLAGS -fomit-frame-pointer")
+   AX_CHECK_COMPILE_FLAG(-ffast-math, CFLAGS="$CFLAGS -ffast-math")
+   #only for intel corei3/5/7 and newer
+   #AX_CHECK_COMPILE_FLAG(-msse4, CFLAGS="$CFLAGS -msse4")
+   #AX_CHECK_COMPILE_FLAG(-msse4.1, CFLAGS="$CFLAGS -msse4.1")
+   #AX_CHECK_COMPILE_FLAG(-msse4.2, CFLAGS="$CFLAGS -msse4.2")
+fi
 
 
 # Checks for header files.
-AC_HEADER_DIRENT
 AC_HEADER_STDC
+AC_HEADER_DIRENT
 AC_HEADER_TIME
 AC_CHECK_HEADERS([stdlib.h string.h sys/time.h sys/timeb.h termios.h unistd.h])
-
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -73,6 +103,13 @@ AC_TYPE_SIZE_T
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T
 
+dnl get X11 default libs
+AC_PATH_XTRA
+CPPFLAGS="$CPPFLAGS $X_CFLAGS"
+LIBS="$X_PRE_LIBS $LIBS $X_LIBS $X_EXTRA_LIBS"
+
+#check if we need to link with -lm
+AC_CHECK_LIB([m], [pow])
 
 # Checks for library functions.
 AC_FUNC_CLOSEDIR_VOID
@@ -97,25 +134,35 @@ fi
 AC_SUBST(WINDRES)
 AM_CONDITIONAL(USE_ICON_RC, test x$use_icon_rc = xtrue)
 
+
 dnl Call in pkg-config explicitly, so we can safely put the first
 dnl PKG_CHECK_EXISTS inside an if
 PKG_PROG_PKG_CONFIG
-
 
 dnl Check for SDL
 SDL_VERSION=1.2.10
 AC_SUBST(SDL_VERSION)
 AM_PATH_SDL($SDL_VERSION, :, [AC_MSG_ERROR(SDL is required for Gravit)])
 CFLAGS="$CFLAGS $SDL_CFLAGS"
+CPPFLAGS="$CPPFLAGS $SDL_CFLAGS"
 LIBS="$LIBS $SDL_LIBS"
 
 # Checks for libraries.
 AC_CHECK_LIB([SDL_image], [IMG_Load], [], [AC_MSG_ERROR(SDL_image is required)])
 AC_CHECK_LIB([SDL_ttf], [TTF_Init], [], [AC_MSG_ERROR(SDL_ttf is required)])
 
-
+dnl Check for OpenGL - try pkg-config first
+PKG_CHECK_EXISTS([gl], [have_gl=yes], [have_gl=no])
+PKG_CHECK_EXISTS([glu], [have_glu=yes], [have_glu=no])
+if test x"$have_gl" = x"yes" -a  x"$have_glu" = x"yes" ; then
+   PKG_CHECK_MODULES(GL, [gl])
+   PKG_CHECK_MODULES(GLU, [glu])
+   #GLU requires GL, so it's enough to use GLU_CFLAGS and GLU_LIBS
+   CFLAGS="$CFLAGS $GLU_CFLAGS"
+   LIBS="$LIBS $GLU_LIBS"
+else
 dnl Check for OpenGL - borrowed from SDL_ttf
-case "$host" in
+   case "$host" in
     *-*-cygwin* | *-*-mingw*)
         MATHLIB=""
         SYS_GL_LIBS="-lopengl32 -lglu32"
@@ -148,25 +195,25 @@ case "$host" in
             SYS_GL_LIBS="-lGL -lGLU"
         fi
         ;;
-esac
-AC_MSG_CHECKING(for OpenGL support)
-have_opengl=no
-AC_TRY_COMPILE([
- #include "SDL_opengl.h"
-],[
- GLuint texture;
-],[
-have_opengl=yes
-])
-AC_MSG_RESULT($have_opengl)
-if test x$have_opengl = xyes; then
-    GL_LIBS="$SYS_GL_LIBS"
-else
-    GL_LIBS=""
-    AC_MSG_ERROR(GL is required)
+   esac
+   AC_MSG_CHECKING(for OpenGL support)
+   have_opengl=no
+   AC_TRY_COMPILE([
+    #include "SDL_opengl.h"
+   ],[
+    GLuint texture;
+   ],[
+   have_opengl=yes
+   ])
+   AC_MSG_RESULT($have_opengl)
+   if test x$have_opengl = xyes; then
+       GL_LIBS="$SYS_GL_LIBS"
+   else
+       GL_LIBS=""
+       AC_MSG_ERROR(GL is required)
+   fi
+   LIBS="$LIBS $SYS_GL_LIBS $MATHLIB"
 fi
-LIBS="$LIBS $SYS_GL_LIBS $MATHLIB"
-
 
 dnl Check for lua - borrowed from lighttpd
 AC_MSG_CHECKING(if lua support is requested)

--- a/frame-pp_sse.c
+++ b/frame-pp_sse.c
@@ -110,6 +110,9 @@ static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
 
 
 	// SSE loop - four particles at once
+#ifdef __INTEL_COMPILER
+#pragma vector aligned
+#endif
         for (j = 0; j < vector_limit; j += VECT_SIZE) {
 	    __v128 dv_vx ;
 	    __v128 dv_vy ;

--- a/frame-pp_sse.c
+++ b/frame-pp_sse.c
@@ -38,43 +38,43 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 typedef struct {
-  float * __restrict__ x;
-  float * __restrict__ y;
-  float * __restrict__ z;
-  float * __restrict__ mass;
+    float * __restrict__ x;
+    float * __restrict__ y;
+    float * __restrict__ z;
+    float * __restrict__ mass;
 } particle_vectors;
 
 typedef struct {
-  float * __restrict__ x;
-  float * __restrict__ y;
-  float * __restrict__ z;
+    float * __restrict__ x;
+    float * __restrict__ y;
+    float * __restrict__ z;
 } vel_vectors;
 
 
 #include "sse_functions.h"
 
 
-  /*  Optimizations:
-      ===============
-      * before processing, copy particle data to vector-friendly arrays
-      * use SSE to process four particles at once
-      * delay multiplication with G
-      * after processing, write back results
-  */
+/*  Optimizations:
+    ===============
+    * before processing, copy particle data to vector-friendly arrays
+    * use SSE to process four particles at once
+    * delay multiplication with G
+    * after processing, write back results
+*/
 
 
 #define MIN_STEP2 0.05f
 static const __v128 vmin_step2 = _mm_init1_ps(MIN_STEP2);
 
-//static void __attribute__((hot)) 
-static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel, 
-                              int start, int amount) {
-     int i;
+//static void __attribute__((hot))
+static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
+                                  int start, int amount) {
+    int i;
 
     // apply gravity to every specified velocity
-    #ifdef _OPENMP
-    #pragma omp parallel for schedule(dynamic, 256)
-    #endif
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic, 256)
+#endif
     for (i = start; i < amount; i++) {
         __v128 p1_vpos_x ;
         __v128 p1_vpos_y ;
@@ -87,7 +87,7 @@ static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
 
         //VectorNew(p1_pos);
         //VectorNew(p1_vel);
-	//VectorZero(p1_vel);
+        //VectorZero(p1_vel);
 
         float p1_pos_x;
         float p1_pos_y;
@@ -100,37 +100,37 @@ static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
 
 
         int j;
-	int vector_limit;
-       	vector_limit = (i / VECT_SIZE) * VECT_SIZE;  // round down to value divisible by 4
+        int vector_limit;
+        vector_limit = (i / VECT_SIZE) * VECT_SIZE;  // round down to value divisible by 4
 
-	p1_vpos_x = _mm_set1_ps(pos.x[i]);
-	p1_vpos_y = _mm_set1_ps(pos.y[i]);
-	p1_vpos_z = _mm_set1_ps(pos.z[i]);
-	p1_vmass  = _mm_set1_ps(pos.mass[i]);
+        p1_vpos_x = _mm_set1_ps(pos.x[i]);
+        p1_vpos_y = _mm_set1_ps(pos.y[i]);
+        p1_vpos_z = _mm_set1_ps(pos.z[i]);
+        p1_vmass  = _mm_set1_ps(pos.mass[i]);
 
 
-	// SSE loop - four particles at once
+        // SSE loop - four particles at once
 #ifdef __INTEL_COMPILER
 #pragma vector aligned
 #endif
         for (j = 0; j < vector_limit; j += VECT_SIZE) {
-	    __v128 dv_vx ;
-	    __v128 dv_vy ;
-	    __v128 dv_vz ;
-	    __v128 vInvSqDist;
-	    __v128 vforce;
+            __v128 dv_vx ;
+            __v128 dv_vy ;
+            __v128 dv_vz ;
+            __v128 vInvSqDist;
+            __v128 vforce;
 
-	    dv_vx = V_SUB( p1_vpos_x, LOAD_V4(pos.x, j));
-	    dv_vy = V_SUB( p1_vpos_y, LOAD_V4(pos.y, j));
-	    dv_vz = V_SUB( p1_vpos_z, LOAD_V4(pos.z, j));
+            dv_vx = V_SUB( p1_vpos_x, LOAD_V4(pos.x, j));
+            dv_vy = V_SUB( p1_vpos_y, LOAD_V4(pos.y, j));
+            dv_vz = V_SUB( p1_vpos_z, LOAD_V4(pos.z, j));
 
             // get distance^2 between the two
-	    vInvSqDist  = V_MUL( dv_vx, dv_vx);
-	    V_INCR( vInvSqDist, V_MUL( dv_vy, dv_vy));
-	    V_INCR( vInvSqDist, V_MUL( dv_vz, dv_vz));
-	    V_INCR( vInvSqDist, vmin_step2);
+            vInvSqDist  = V_MUL( dv_vx, dv_vx);
+            V_INCR( vInvSqDist, V_MUL( dv_vy, dv_vy));
+            V_INCR( vInvSqDist, V_MUL( dv_vz, dv_vz));
+            V_INCR( vInvSqDist, vmin_step2);
 
-	    /* compute acceleration */
+            /* compute acceleration */
             vforce = V_MUL( V_MUL( p1_vmass, LOAD_V4(pos.mass, j)), newtonrapson_rcp(vInvSqDist));
 
             // sum of accelerations for p1
@@ -146,35 +146,35 @@ static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
         }
 
 
-	// cache p1 data
-	p1_pos_x = pos.x[i];
-	p1_pos_y = pos.y[i];
-	p1_pos_z = pos.z[i];
-	p1_mass   = pos.mass[i];
+        // cache p1 data
+        p1_pos_x = pos.x[i];
+        p1_pos_y = pos.y[i];
+        p1_pos_z = pos.z[i];
+        p1_mass   = pos.mass[i];
 
-	// copy vector results  to single floats
-	p1_vel_x = _vector4_sum(p1_vvel_x);
-	p1_vel_y = _vector4_sum(p1_vvel_y);
-	p1_vel_z = _vector4_sum(p1_vvel_z);
+        // copy vector results  to single floats
+        p1_vel_x = _vector4_sum(p1_vvel_x);
+        p1_vel_y = _vector4_sum(p1_vvel_y);
+        p1_vel_z = _vector4_sum(p1_vvel_z);
 
 
-	// do the remaining particles without SSE
+        // do the remaining particles without SSE
         for (j = vector_limit; j < i; j++) {
-	    VectorNew(dv);
-	    float inverseSquareDistance;
-	    float force;
+            VectorNew(dv);
+            float inverseSquareDistance;
+            float force;
 
             dv[0] = p1_pos_x - pos.x[j];
             dv[1] = p1_pos_y - pos.y[j];
             dv[2] = p1_pos_z - pos.z[j];
 
             // get distance^2 between the two
-	    inverseSquareDistance  = dv[0] * dv[0];
-	    inverseSquareDistance += dv[1] * dv[1];
-	    inverseSquareDistance += dv[2] * dv[2];
-	    inverseSquareDistance +=  + MIN_STEP2;
+            inverseSquareDistance  = dv[0] * dv[0];
+            inverseSquareDistance += dv[1] * dv[1];
+            inverseSquareDistance += dv[2] * dv[2];
+            inverseSquareDistance +=  + MIN_STEP2;
 
-	    /* compute acceleration */
+            /* compute acceleration */
             force = p1_mass * pos.mass[j] / inverseSquareDistance;
 
             // sum of accelerations for p1
@@ -226,12 +226,11 @@ void processFramePP_SSE(int start, int amount) {
 
 
     // copy frame data to vector-friendly arrays
-    for (i=0; i<particles_max; i++)
-	{
-	  pos.x[i] = framebase[i].pos[0];
-	  pos.y[i] = framebase[i].pos[1];
-	  pos.z[i] = framebase[i].pos[2];
-	  pos.mass[i] = state.particleDetail[i].mass;
+    for (i=0; i<particles_max; i++) {
+        pos.x[i] = framebase[i].pos[0];
+        pos.y[i] = framebase[i].pos[1];
+        pos.z[i] = framebase[i].pos[2];
+        pos.mass[i] = state.particleDetail[i].mass;
     }
 
 
@@ -240,11 +239,10 @@ void processFramePP_SSE(int start, int amount) {
 
 
     // write back results
-    for (i=0; i<particles_max; i++)
-    {
-	  framebase[i].vel[0] += vel.x[i] * state.g;
-	  framebase[i].vel[1] += vel.y[i] * state.g;
-	  framebase[i].vel[2] += vel.z[i] * state.g;
+    for (i=0; i<particles_max; i++) {
+        framebase[i].vel[0] += vel.x[i] * state.g;
+        framebase[i].vel[1] += vel.y[i] * state.g;
+        framebase[i].vel[2] += vel.z[i] * state.g;
     }
 
 

--- a/frame-pp_vector.c
+++ b/frame-pp_vector.c
@@ -58,15 +58,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
   //#define FREE_16(target)                    {_mm_free(target);}
 
 #else
-  // linux, unix, MacOS:  use posix_memalign
+  // linux, unix, MacOS:  use (posix_)memalign
   #include <stdlib.h>
   #include <malloc.h>
-  #if defined(HAVE_MEMALIGN) && !defined(HAVE_WORKING_POSIX_MEMALIGN)
-  // use memalign, because test for working posix_memalign failed
+  //  #if defined(HAVE_MEMALIGN) && !defined(HAVE_WORKING_POSIX_MEMALIGN)
+  #if defined(HAVE_MEMALIGN)
+  // use memalign -- seems this is the best choice for most unix/linux versions
     #define MALLOC_16(target, size, alignment) {target =  (float*) memalign(alignment, size);}
     #define FREE_16(target)                    {free(target);}
   #else
-  // default: use posix_memalign
+  // all others use posix_memalign
     #define MALLOC_16(target, size, alignment) {if (posix_memalign( (void **) &(target), alignment, size) != 0) target=NULL;}
     #define FREE_16(target)                    {free(target);}
   #endif
@@ -80,10 +81,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 // if your compiler complains, just remove __restrict__
 
 #ifdef _MSC_VER
-//#define __restrict__ __restrict
+#define __restrict__ __restrict
 //#define __restrict__ __declspec(restrict)
-// problems with openMP
-#define __restrict__
+//#define __restrict__
 #endif
 
 

--- a/frame-pp_vector.c
+++ b/frame-pp_vector.c
@@ -29,9 +29,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 /* ************************************************************************** */
 /* How to allocate memory with 16byte alignment?                              */
 /* ************************************************************************** */
-
-// Windows: use _aligned_malloc
 #ifdef WIN32
+  // Windows: use _aligned_malloc
   #include <stdlib.h>
   #include <malloc.h>
   #if defined(__MINGW32__) || defined(mingw32) || defined(MINGW)
@@ -44,35 +43,22 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
     #define FREE_16(target)                    {_aligned_free(target);}
   #endif
 
-  // #if !defined(__INTEL_COMPILER) && !defined(__OPENCC__)
-  // intel and amd compilers do not like this ..
-  // #include <malloc.h>
-  // #include <mm_malloc.h>
-  // #endif
-  // #ifdef __OPENCC__
-  // #include <xmmintrin.h>
-  // #endif
-
-  // alternative: _mm_malloc 
-  //#define MALLOC_16(target, size, alignment) {target =  (float*) _mm_malloc(size, alignment);}
-  //#define FREE_16(target)                    {_mm_free(target);}
-
 #else
   // linux, unix, MacOS:  use (posix_)memalign
   #include <stdlib.h>
   #include <malloc.h>
-  //  #if defined(HAVE_MEMALIGN) && !defined(HAVE_WORKING_POSIX_MEMALIGN)
+  //#if defined(HAVE_MEMALIGN) && !defined(HAVE_WORKING_POSIX_MEMALIGN)
   #if defined(HAVE_MEMALIGN)
-  // use memalign -- seems this is the best choice for most unix/linux versions
+    // use memalign -- seems this is the best choice for most unix/linux versions
     #define MALLOC_16(target, size, alignment) {target =  (float*) memalign(alignment, size);}
     #define FREE_16(target)                    {free(target);}
   #else
-  // all others use posix_memalign
+    // all others use posix_memalign
     #define MALLOC_16(target, size, alignment) {if (posix_memalign( (void **) &(target), alignment, size) != 0) target=NULL;}
     #define FREE_16(target)                    {free(target);}
   #endif
-#endif
 
+#endif
 /* ************************************************************************** */
 
 

--- a/frame-pp_vector.c
+++ b/frame-pp_vector.c
@@ -1,0 +1,217 @@
+/*
+
+Gravit - A gravity simulator
+Copyright 2003-2005 Gerald Kaszuba
+
+Gravit is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Gravit is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Gravit; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*/
+
+#include "gravit.h"
+
+#ifdef _OPENMP
+// experimental OMP support
+#include <omp.h> // VC has to include this header to build the correct manifest to find vcom.dll or vcompd.dll
+#endif
+
+
+// mm_malloc gives back aligned blocks
+#if !defined(__INTEL_COMPILER) && !defined(__OPENCC__)
+   // intel and amd compilers do not like this ..
+#include <malloc.h>
+#include <mm_malloc.h>
+#endif
+
+#ifdef __OPENCC__
+#include <xmmintrin.h>
+#endif
+
+// __restrict__ tell the compiler that two pointer will not point to the same location
+// if your compiler complains, just remove __restrict__
+
+#ifdef _MSC_VER
+//#define __restrict__ __restrict
+//#define __restrict__ __declspec(restrict)
+// problems with openMP
+#define __restrict__
+#endif
+
+
+
+
+typedef struct {
+  float * __restrict__ x;
+  float * __restrict__ y;
+  float * __restrict__ z;
+  float * __restrict__ mass;
+} particle_vectors;
+
+typedef struct {
+  float * __restrict__ x;
+  float * __restrict__ y;
+  float * __restrict__ z;
+} vel_vectors;
+
+
+
+
+  /*  Optimizations:
+      ===============
+      * before processing, copy particle data to vector-friendly arrays
+      * delay multiplication with G
+      * after processing, write back results
+  */
+
+
+//#define MIN_STEP2 0.05
+
+static void do_processFramePP(particle_vectors pos, vel_vectors vel, 
+                              int start, int amount) {
+     int i;
+     //int particles_max = state.particleCount;
+
+    // apply gravity to every specified velocity
+    #ifdef _OPENMP
+    #pragma omp parallel for schedule(dynamic, 256)
+    #endif
+    for (i = start; i < amount; i++) {
+        //VectorNew(p1_pos);
+        float p1_pos_x;
+        float p1_pos_y;
+        float p1_pos_z;
+        float p1_mass;
+
+        //VectorNew(p1_vel);
+	//VectorZero(p1_vel);
+        float p1_vel_x = 0.0f;
+        float p1_vel_y = 0.0f;
+        float p1_vel_z = 0.0f;
+
+        int j;
+
+	p1_pos_x = pos.x[i];
+	p1_pos_y = pos.y[i];
+	p1_pos_z = pos.z[i];
+	p1_mass   = pos.mass[i];
+
+
+#ifdef __INTEL_COMPILER
+#pragma vector aligned
+#endif
+        for (j = 0; j < i; j++) {
+	    //VectorNew(dv);
+	    float dv_x;
+	    float dv_y;
+	    float dv_z;
+	    float inverseSquareDistance;
+	    float force;
+
+            dv_x = p1_pos_x - pos.x[j];
+            dv_y = p1_pos_y - pos.y[j];
+            dv_z = p1_pos_z - pos.z[j];
+
+            // get distance^2 between the two
+	    inverseSquareDistance  = dv_x * dv_x;
+	    inverseSquareDistance += dv_y * dv_y;
+	    inverseSquareDistance += dv_z * dv_z;
+	    //inverseSquareDistance +=  + MIN_STEP2;
+
+            force = p1_mass * pos.mass[j] / inverseSquareDistance;
+
+            // sum of accelerations for p1
+            p1_vel_x += dv_x * force;
+            p1_vel_y += dv_y * force;
+            p1_vel_z += dv_z * force;
+
+            // add acceleration for p2 (with negative sign, as the direction is inverted)
+            vel.x[j] -= dv_x * force;
+            vel.y[j] -= dv_y * force;
+            vel.z[j] -= dv_z * force;
+
+        }
+
+        // write back buffered acceleration of p1
+        vel.x[i] += p1_vel_x;
+        vel.y[i] += p1_vel_y;
+        vel.z[i] += p1_vel_z;
+
+    }
+
+}
+
+
+
+void processFramePP(int start, int amount) {
+    particle_vectors pos;
+    vel_vectors vel;
+    particle_t *framebase = state.particleHistory + state.particleCount*state.frame;
+
+    int i;
+    int particles_max;
+    particles_max = state.particleCount;
+
+
+    // create arrays, aligned to 16 bytes
+
+    pos.x = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.y = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.z = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    pos.mass = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    //memset(pos.x, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.y, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.z, 0, sizeof(float) * (particles_max + 16));
+    //memset(pos.mass, 0, sizeof(float) * (particles_max + 16));
+    vel.x = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    vel.y = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    vel.z = (float*) _mm_malloc(sizeof(float)*(particles_max + 16), 16);
+    memset(vel.x, 0, sizeof(float) * (particles_max + 16));
+    memset(vel.y, 0, sizeof(float) * (particles_max + 16));
+    memset(vel.z, 0, sizeof(float) * (particles_max + 16));
+
+
+    // copy frame data to vector-friendly arrays
+    for (i=0; i<particles_max; i++)
+	{
+	  pos.x[i] = framebase[i].pos[0];
+	  pos.y[i] = framebase[i].pos[1];
+	  pos.z[i] = framebase[i].pos[2];
+	  pos.mass[i] = state.particleDetail[i].mass;
+    }
+
+
+    // calculate new accelerations
+    do_processFramePP(pos, vel, start, amount);
+
+
+    // write back results
+    for (i=0; i<particles_max; i++)
+    {
+	  framebase[i].vel[0] += vel.x[i] * state.g;
+	  framebase[i].vel[1] += vel.y[i] * state.g;
+	  framebase[i].vel[2] += vel.z[i] * state.g;
+    }
+
+
+    // clean up
+    _mm_free(pos.x);
+    _mm_free(pos.y);
+    _mm_free(pos.z);
+    _mm_free(pos.mass);
+
+    _mm_free(vel.x);
+    _mm_free(vel.y);
+    _mm_free(vel.z);
+
+}

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -27,8 +27,6 @@
 #else
 /* ******************************************************************* */
 // use gcc extensions for SSE 
-//#if !defined(__INTEL_COMPILER)
-   // INTEL and AMD compilers do not like this ..
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40500
     // x86intrin.h availeable since gcc 4.5.0
 #include <malloc.h>
@@ -37,22 +35,19 @@
 #else
 #include <xmmintrin.h>
 #endif
+
+#if !defined(__INTEL_COMPILER)
 #include <mm_malloc.h>
+#endif
 #include <malloc.h>
 typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
 #define _mm_init1_ps(f) {f, f, f, f}
 
 #if defined(__MINGW32__) || defined(mingw32) || defined(MINGW)
+// workaround for buggy _mm_malloc in mingw
 #define _aligned_free __mingw_aligned_free
 #define _aligned_malloc __mingw_aligned_malloc
 #endif
-
-//#else
-// for intel compiler
-//#include <xmmintrin.h>
-//#define __v128 __m128
-//#define _mm_init1_ps(f) {f, f, f, f}
-//#endif
 
 #define ALIGNED __attribute__((aligned (16))) 
 #define ALWAYS_INLINE(ret_type) static inline ret_type __attribute__((__gnu_inline__, __always_inline__, __artificial__)) 

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -17,18 +17,18 @@
 //#define __SSE__
 //#define __SSE2__
 //#endif
-#define ALWAYS_INLINE(ret_type) static __forceinline ret_type 
+#define ALWAYS_INLINE(ret_type) static __forceinline ret_type
 
 #else
-#define ALWAYS_INLINE(ret_type) static inline ret_type 
+#define ALWAYS_INLINE(ret_type) static inline ret_type
 #endif
 
 
 #else
 /* ******************************************************************* */
-// use gcc extensions for SSE 
+// use gcc extensions for SSE
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40500
-    // x86intrin.h availeable since gcc 4.5.0
+// x86intrin.h availeable since gcc 4.5.0
 #include <malloc.h>
 #include <xmmintrin.h>
 #include <x86intrin.h>
@@ -49,8 +49,8 @@ typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  
 #define _aligned_malloc __mingw_aligned_malloc
 #endif
 
-#define ALIGNED __attribute__((aligned (16))) 
-#define ALWAYS_INLINE(ret_type) static inline ret_type __attribute__((__gnu_inline__, __always_inline__, __artificial__)) 
+#define ALIGNED __attribute__((aligned (16)))
+#define ALWAYS_INLINE(ret_type) static inline ret_type __attribute__((__gnu_inline__, __always_inline__, __artificial__))
 
 #endif
 
@@ -88,8 +88,8 @@ typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  
 #define V_SUB(a, b) ( (a) - (b))
 #define V_MUL(a, b) ( (a) * (b))
 #define V_DIV(a, b) ( (a) / (b))
-#define V_INCR(a, b) {a += (b);} 
-#define V_DECR(a, b) {a -= (b);} 
+#define V_INCR(a, b) {a += (b);}
+#define V_DECR(a, b) {a -= (b);}
 
 #else
 // use SSE macros .. somehow faster ...
@@ -97,15 +97,15 @@ typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  
 #define V_SUB(a, b) _mm_sub_ps((a), (b))
 #define V_MUL(a, b) _mm_mul_ps((a), (b))
 #define V_DIV(a, b) _mm_div_ps((a), (b))
-#define V_INCR(a, b) {a = _mm_add_ps( (a), (b));} 
-#define V_DECR(a, b) {a = _mm_sub_ps( (a), (b));} 
+#define V_INCR(a, b) {a = _mm_add_ps( (a), (b));}
+#define V_DECR(a, b) {a = _mm_sub_ps( (a), (b));}
 #endif
 
 
 /* ******************************************************************* */
 // aux. constants
-static const __v128 _half4 = _mm_init1_ps(.5f); 
-static const __v128 _three4= _mm_init1_ps(3.f); 
+static const __v128 _half4 = _mm_init1_ps(.5f);
+static const __v128 _three4= _mm_init1_ps(3.f);
 static const __v128 _two4  = _mm_init1_ps(2.f);
 
 
@@ -120,16 +120,15 @@ static const __v128 _two4  = _mm_init1_ps(2.f);
 #define newtonrapson_rsqrt4( v ) _mm_rsqrt_ps( v )
 
 #else
-ALWAYS_INLINE(__v128) newtonrapson_rsqrt4( const __v128 v ) 
-{
-  //  x = rsqrt_approx(v);
-  //  x' = 0.5 * x * (3 - v*x*x);
+ALWAYS_INLINE(__v128) newtonrapson_rsqrt4( const __v128 v ) {
+    //  x = rsqrt_approx(v);
+    //  x' = 0.5 * x * (3 - v*x*x);
 
-  __v128 approx = _mm_rsqrt_ps( v );
-  // one newton-rapson step to improve accuracy
-  return V_MUL( V_MUL(_half4, approx), 
-		               V_SUB(_three4, 
-				          V_MUL( V_MUL(v, approx), approx) ) );
+    __v128 approx = _mm_rsqrt_ps( v );
+    // one newton-rapson step to improve accuracy
+    return V_MUL( V_MUL(_half4, approx),
+                  V_SUB(_three4,
+                        V_MUL( V_MUL(v, approx), approx) ) );
 }
 #endif
 
@@ -145,14 +144,13 @@ ALWAYS_INLINE(__v128) newtonrapson_rsqrt4( const __v128 v )
 #define newtonrapson_rcp( v ) _mm_rcp_ps( v )
 
 #else
-ALWAYS_INLINE(__v128) newtonrapson_rcp(const __v128 v)
-{
-  //  x = reciprocal_approx(v);
-  //  x' = x * (2 - x * v); 
-  //   --> x' = 2x - x( x*v) = (x+x) - x (x*v)
+ALWAYS_INLINE(__v128) newtonrapson_rcp(const __v128 v) {
+    //  x = reciprocal_approx(v);
+    //  x' = x * (2 - x * v);
+    //   --> x' = 2x - x( x*v) = (x+x) - x (x*v)
 
-  __v128 r = _mm_rcp_ps(v);
-  return (V_SUB( V_ADD(r, r), V_MUL( r, V_MUL(r, v))));
+    __v128 r = _mm_rcp_ps(v);
+    return (V_SUB( V_ADD(r, r), V_MUL( r, V_MUL(r, v))));
 }
 #endif
 
@@ -163,14 +161,13 @@ ALWAYS_INLINE(__v128) newtonrapson_rcp(const __v128 v)
 /*                           ret = v[0] + v[1] + v[2] + v[3]           */
 /* ******************************************************************* */
 
-ALWAYS_INLINE(float) _vector4_sum(const __v128 v)
-{ 
-  __v128 a;
+ALWAYS_INLINE(float) _vector4_sum(const __v128 v) {
+    __v128 a;
 
-  a = _mm_shuffle_ps(v,v, _MM_SHUFFLE(0,3,0,1));                             // 1->0, 3->2; 
-  a = V_ADD(a, v);                                                           // 0+1, 1+0, 2+3, 3+2
-  return(_mm_cvtss_f32(V_ADD(a, _mm_shuffle_ps(a,a, _MM_SHUFFLE(0,0,0,2)))));// 2->0
-                                                                             // 0 = 1 + 0 + 3 + 2
+    a = _mm_shuffle_ps(v,v, _MM_SHUFFLE(0,3,0,1));                             // 1->0, 3->2;
+    a = V_ADD(a, v);                                                           // 0+1, 1+0, 2+3, 3+2
+    return(_mm_cvtss_f32(V_ADD(a, _mm_shuffle_ps(a,a, _MM_SHUFFLE(0,0,0,2)))));// 2->0
+    // 0 = 1 + 0 + 3 + 2
 }
 
 

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -27,19 +27,36 @@
 #else
 /* ******************************************************************* */
 // use gcc extensions for SSE 
+//#if !defined(__INTEL_COMPILER)
+   // INTEL and AMD compilers do not like this ..
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40500
     // x86intrin.h availeable since gcc 4.5.0
+#include <malloc.h>
+#include <xmmintrin.h>
 #include <x86intrin.h>
 #else
 #include <xmmintrin.h>
 #endif
-
 #include <mm_malloc.h>
+#include <malloc.h>
+typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
+#define _mm_init1_ps(f) {f, f, f, f}
+
+#if defined(__MINGW32__) || defined(mingw32) || defined(MINGW)
+#define _aligned_free __mingw_aligned_free
+#define _aligned_malloc __mingw_aligned_malloc
+#endif
+
+//#else
+// for intel compiler
+//#include <xmmintrin.h>
+//#define __v128 __m128
+//#define _mm_init1_ps(f) {f, f, f, f}
+//#endif
+
 #define ALIGNED __attribute__((aligned (16))) 
 #define ALWAYS_INLINE(ret_type) static inline ret_type __attribute__((__gnu_inline__, __always_inline__, __artificial__)) 
 
-typedef float __v128 __attribute__(( vector_size(4*sizeof(float)) ,aligned(16)  ));
-#define _mm_init1_ps(f) {f, f, f, f}
 #endif
 
 


### PR DESCRIPTION
Hi gerald,

I have build a version of frame-pp.c that is almost as fast as frame-pp_sse, if you have a compiler that can do auto-vectorization. (i.e. the intel "icc" compiler on linux). It is meant as a replacement for frame-pp.c .

Additionally, the patches include some code cleanup, and reformatting of some files with astyle -A2.

best wishes, 
  Frank.
