### PR TITLE
here is another small change ...

### DIFF
--- a/command.c
+++ b/command.c
@@ -560,6 +560,8 @@ void cmdRecord(char *arg) {
         conAdd(LHELP, "Press F5 to play your recording. Press F6 to stop recording.");
         state.mode |= SM_RECORD;
         setTitle(STRING_RECORD);
+        view.timed_frames=0;
+        view.totalRenderTime=0;
 
     }
 

--- a/font.h
+++ b/font.h
@@ -39,8 +39,8 @@ void drawFontWordRA(float x, float y, char *word);
 void drawFontWordCA(float x, float y, char *word);
 float drawFontWord(float x, float y, char *word);
 int loadFonts();
-float getWordWidth(char *s);
-float getnWordWidth(char *s, int n);
+PURE_F float getWordWidth(char *s);
+PURE_F float getnWordWidth(char *s, int n);
 
 #endif
 

--- a/frame-pp_sse.c
+++ b/frame-pp_sse.c
@@ -66,7 +66,7 @@ typedef struct {
 #define MIN_STEP2 0.05f
 static const __v128 vmin_step2 = _mm_init1_ps(MIN_STEP2);
 
-//static void __attribute__((hot))
+HOT
 static void do_processFramePP_SSE(particle_vectors pos, vel_vectors vel,
                                   int start, int amount) {
     int i;

--- a/frame-pp_vector.c
+++ b/frame-pp_vector.c
@@ -182,7 +182,7 @@ static void do_processFramePP(particle_vectors pos, vel_vectors vel,
 void processFramePP(int start, int amount) {
     particle_vectors pos;
     vel_vectors vel;
-    particle_t *framebase = state.particleHistory + state.particleCount*state.frame;
+    particle_t * __restrict__ framebase = state.particleHistory + state.particleCount*state.frame;
 
     int i;
     int particles_max;

--- a/frame-pp_vector.c
+++ b/frame-pp_vector.c
@@ -101,6 +101,7 @@ typedef struct {
 
 //#define MIN_STEP2 0.05
 
+HOT
 static void do_processFramePP(particle_vectors pos, vel_vectors vel,
                               int start, int amount) {
     int i;
@@ -132,6 +133,7 @@ static void do_processFramePP(particle_vectors pos, vel_vectors vel,
 
 
 #ifdef __INTEL_COMPILER
+#pragma vector always
 #pragma vector aligned
 #endif
         for (j = 0; j < i; j++) {

--- a/frame.c
+++ b/frame.c
@@ -71,6 +71,10 @@ int initFrame() {
     state.memoryAllocated += FRAMEDETAILSIZE;
 
     memset(state.particleHistory, 0, FRAMESIZE);
+
+    view.timed_frames=0;
+    view.totalRenderTime=0;
+
     fpsInit();
 
     return 1;
@@ -139,6 +143,8 @@ void processFrame() {
 
     int i;
     particle_t *p;
+    Uint32 frameStart = 0;
+    Uint32 frameEnd = 0;
 
 //	processMomentum();
 
@@ -176,6 +182,8 @@ void processFrame() {
         }
 
     }
+
+    frameStart = getMS();
 
 #ifdef _OPENMP
     omp_set_num_threads(state.processFrameThreads);
@@ -229,6 +237,11 @@ void processFrame() {
     }
 
     state.totalFrames ++;
+
+    frameEnd = getMS();
+    view.totalRenderTime += frameEnd - frameStart;
+    view.timed_frames ++;
+
 
     if (state.frameCompression && (state.totalFrames % state.historyNFrame)) {
 

--- a/gravit.h
+++ b/gravit.h
@@ -29,6 +29,24 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "config.h"
 #endif
 
+
+// a few gcc-specific attributes
+#ifdef __GNUC__
+  #if __GNUC__ >= 4 && __GNUC_MINOR__ >= 3
+    #define HOT __attribute__((hot))
+  #else
+    #define HOT
+  #endif
+
+  #define CONST_F __attribute__((const))
+  #define PURE_F  __attribute__((pure))
+#else
+  #define HOT
+  #define CONST_F
+  #define PURE_F
+#endif
+
+
 // normally /etc
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "."
@@ -274,7 +292,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 // this define is to render video in the middle of a spawn
 #define doVideoUpdateInSpawn() \
 	if (view.recordingVideoRefreshTime) { \
-		if (view.lastVideoFrame + view.recordingVideoRefreshTime < getMS()) { \
+		if (view.lastVideoFrame + (view.recordingVideoRefreshTime*2) < getMS()) { \
 			runInput(); \
 			runVideo(); \
 		} \
@@ -591,9 +609,10 @@ int commandLineRead(int argc, char *argv[]);
 
 // tool.c
 char * va( char *format, ... );
-int gfxPowerOfTwo(int input);
+CONST_F int gfxPowerOfTwo(int input);
 int LoadMemoryDump(char *fileName, unsigned char *d, size_t size);
 int SaveMemoryDump(char *FileName, unsigned char *d, size_t total);
+
 Uint32 getMS();
 void setTitle(char *state);
 int mymkdir(const char *path);

--- a/gravit.h
+++ b/gravit.h
@@ -446,6 +446,10 @@ typedef struct view_s {
 
     Uint32 firstTimeStamp;
 
+    // timer for rendering
+    Uint32 totalRenderTime;
+    Uint32 timed_frames;
+
     int quit;
 
     Uint8 mouseButtons[2];	// 0 now, 1 last

--- a/main.c
+++ b/main.c
@@ -143,6 +143,8 @@ void viewInit() {
     view.stereoOSD = 0;
 
     cmdFps(NULL);
+    view.timed_frames=0;
+    view.totalRenderTime=0;
 
     memset(view.keys, 0, sizeof(view.keys));
 

--- a/osd.c
+++ b/osd.c
@@ -138,6 +138,21 @@ void drawOSD() {
 
         }
 
+
+        // show renderer FPS average (if we have meaningful values)
+        if ((view.timed_frames > 1) && (view.totalRenderTime > SDL_TIMESLICE )) {
+            if (state.mode & SM_RECORD) {
+	      glColor4f(0,1,1,.5f); /*torquise*/ }
+              else { DUHC(); y += fontHeight; }
+
+	    DUH("avg renderer fps", va("%5.2f",
+                     (float) view.timed_frames/ (float) view.totalRenderTime * 1000.0f ))
+	    DUH("avg renderer frame time", va("%4.1f ms",
+		     (float) view.totalRenderTime / (float) view.timed_frames ));
+	    DUHC();
+        }
+
+
         /*
         		big = state.particleCount*state.particleCount-state.particleCount;
         		DUH("total calcs", va("%-5i %3.2f%% (max: %i)", otGetNCalcs(), (float)otGetNCalcs()/big*100, state.particleCount*state.particleCount-state.particleCount));
@@ -158,7 +173,7 @@ void drawOSD() {
         DUHC();
         DUH("F1", "General Shortcut Keys");
         DUH("F2", "Visual Effects Keys");
-        DUH("` (above TAB)", "Use the Console");
+        DUH("` (above TAB) or 1", "Use the Console");
         DUH("ESC", "Exit Console/Help/Gravit");
 
     }

--- a/osd.c
+++ b/osd.c
@@ -98,7 +98,10 @@ void drawOSD() {
             switch (view.recordStatus) {
             case 0:
             default:
-                DUH("status", "dormant");
+	        if (state.mode & SM_RECORD) {
+		    DUH("status", "rendering ...");
+                } else {
+                    DUH("status", "dormant"); }
                 break;
             case 1:
                 DUH("status", va("generating tree %.1f%%", (float)view.recordParticlesDone/state.particleCount*100));

--- a/sse_functions.h
+++ b/sse_functions.h
@@ -18,6 +18,7 @@
 //#define __SSE2__
 //#endif
 #define ALWAYS_INLINE(ret_type) static __forceinline ret_type
+#define ALIGNED __declspec(align(16))
 
 #else
 #define ALWAYS_INLINE(ret_type) static inline ret_type


### PR DESCRIPTION
Hi gerald,
here is another one for you:
- small optimizations in frame-pp_vector.c
- added additional FPS for frame computing time (the normal "frame time" is including too much other stuff to be useful for benchmarking the frame-xx code)

Will you come "back to gravit" soon? We need the windows screen saver setup ...

I still want to to the following changes:
- (easy) enhance the "frame" command: when the target frame does not yet exist, automatically enter recording mode, and auto-stop when having the frame (example: spawn; frame 800 --> records until frame 800, then go idle)
- (ugly job) clean up the windows build env. move all windows-specific stuff to an extra directory; maybe add pre-compiled versions of all required libraries.

cheers,
  Frank.
