### PR TITLE
new feature: record until frame xxx

### DIFF
--- a/command.c
+++ b/command.c
@@ -84,7 +84,8 @@ cmd_t cmd[] = {
 
 //	,{ "fps",						cmdFps,					&view.fps,					NULL,								NULL }
     ,{ "frameskip",					cmdFrameSkip,			NULL,						NULL,								NULL }
-    ,{ "frame",						NULL,					NULL,						&state.currentFrame,				NULL }
+//  ,{ "frame",						NULL,					NULL,						&state.currentFrame,				NULL }
+    ,{ "frame",						cmdFrame,			NULL,						NULL,				NULL }
 
     ,{ "tailskip",					cmdTailSkipCheck,		NULL,						&view.tailSkip,						NULL }
     ,{ "tailfaded",					NULL,					NULL,						&view.tailFaded,					NULL }
@@ -552,6 +553,7 @@ void cmdRecord(char *arg) {
         conAdd(LNORM, "Stopped Recording.");
         conAdd(LHELP, "Press F5 to play your recording. Press F6 to continue recording.");
         state.mode &= ~SM_RECORD;
+        //state.targetFrame = -1;
         setTitle(0);
 
     } else {
@@ -593,8 +595,35 @@ void cmdPlay(char *arg) {
         conAdd(LNORM, "Playing...");
         conAdd(LHELP, "Press F5 to stop playback. Press F6 to continue recording.");
         state.mode |= SM_PLAY;
+        //state.targetFrame = -1;
         setTitle(STRING_PLAY);
 
+    }
+
+}
+
+void cmdFrame(char *arg) {
+    int new_target_frame;
+
+    if ((arg) && (atoi(arg) >= 0)) {
+        new_target_frame=atoi(arg);
+    } else {
+        new_target_frame=state.currentFrame;
+    }
+
+
+    if ( new_target_frame <= state.frame ) {
+        // just set frame to display
+        state.currentFrame = new_target_frame;
+        conAdd(LNORM, "frame = %i", state.currentFrame);
+
+    } else {
+        // set target_frame
+        state.currentFrame = state.frame;
+        state.targetFrame = new_target_frame;
+        // change to record_mode
+	if ((state.mode & SM_RECORD) == 0) cmdRecord(NULL);
+        conAdd(LNORM, "current frame = %i, advancing to frame %i", state.currentFrame, state.targetFrame);
     }
 
 }

--- a/command.h
+++ b/command.h
@@ -50,6 +50,7 @@ void cmdLoadFrameDump(char *arg);
 void cmdRecord(char *arg);
 void cmdStop(char *arg);
 void cmdStart(char *arg);
+void cmdFrame(char *arg);
 void cmdFps(char *arg);
 void cmdSpawn(char *arg);
 void cmdStatus(char *arg);

--- a/frame.c
+++ b/frame.c
@@ -41,6 +41,7 @@ int initFrame() {
     state.totalFrames = 0;
     state.historyNFrame = 1;
     state.currentFrame = 0;
+    state.targetFrame = -1;
     view.quit = 0;
 
     cleanMemory();
@@ -157,6 +158,7 @@ void processFrame() {
         if (state.frameCompression) {
 
             state.frame /= 2;
+            if (state.targetFrame >0) state.targetFrame /= 2;
             state.currentFrame = state.frame;
             state.historyNFrame *= 2;
             conAdd(LLOW, "historyNFrame: %i", state.historyNFrame);
@@ -177,6 +179,7 @@ void processFrame() {
 
         } else {
 
+            state.targetFrame= -1;
             return;
 
         }
@@ -260,6 +263,12 @@ void processFrame() {
     state.frame ++;
     state.currentFrame = state.frame;
 
+    if ((state.targetFrame >= 0) && (state.targetFrame <= state.frame) && (state.mode & SM_RECORD))
+    {
+      conAdd(LNORM, "target frame reached: %i", state.currentFrame);
+      cmdRecord(NULL);
+      state.targetFrame = -1;
+    }
 }
 
 #if 0

--- a/frame.c
+++ b/frame.c
@@ -179,7 +179,9 @@ void processFrame() {
 
         } else {
 
+	    // no more frames left - stop recording
             state.targetFrame= -1;
+            if (state.mode & SM_RECORD) cmdRecord(NULL);
             return;
 
         }

--- a/gravit.h
+++ b/gravit.h
@@ -384,6 +384,7 @@ typedef struct state_s {
     int frame;
     int totalFrames;
     int currentFrame;
+    int targetFrame;
     int historyFrames;
     int historyNFrame;
 

--- a/main.c
+++ b/main.c
@@ -189,6 +189,7 @@ void stateInit() {
     state.processFrameThreads = 1;
 #endif
 
+    state.targetFrame = -1;
 }
 
 int init(int argc, char *argv[]) {

--- a/spawn/functions.lua
+++ b/spawn/functions.lua
@@ -13,12 +13,29 @@ function v(_x, _y, _z)
 	return t
 end
 
+local random_firstuse=1
+function seed_random()
+       local r_seed = os.clock() * 1000 + os.time() + math.random(0,32676)
+       -- improved seeding on some platforms, by throwing away the high part of time,
+       -- then reversing the digits so the least significant part makes the biggest change
+       -- see http://lua-users.org/wiki/MathLibraryTutorial
+       r_seed = tonumber(tostring( r_seed ):reverse():sub(1,8))
+       math.randomseed( r_seed )
+       random_firstuse=0
+end
+
 function randomfloat(min,max)
+        if random_firstuse == 1 then
+	   seed_random();
+        end
 	return math.random() * (max-min) + min
 end
 
 -- returns an integer between min and max inclusive
 function randomint(min,max)
+        if random_firstuse == 1 then
+	   seed_random();
+        end
 	return math.random(min,max)
 end
 


### PR DESCRIPTION
Hi Gerald,
- new feature of the "frame" command: when the target frame does not exist, enter recording mode and go idle when we have that frame. In the future, we may need another command to wait for gravit to become idle. This would allow for scripts like "spawn; frame 2000; WAIT; save junk; screenshot; exit".
- fixed a small problem in spawn/functions.lua, which caused the first simulation to always look very similar (at least on windows). I have added some lines that ensure the LUA random number generator is always seeded with some random stuff before the first use.

best regards,
   Frank.

PS: i will try to take some time for the "ugly windows job" in december ..
