### PR TITLE
reducing console verbosity

### DIFF
--- a/command.c
+++ b/command.c
@@ -512,7 +512,7 @@ restart:
 #endif
 
     state.currentlySpawning = 0;
-    conAdd(LHELP, "You have spawned some particles. Hit F6 to start recording the simulation!");
+    conAdd(LLOW, "You have spawned some particles. Hit F6 to start recording the simulation!");
 
     state.mode = 0;
 

--- a/console.c
+++ b/console.c
@@ -397,7 +397,7 @@ void conAutoComplete() {
             }
 
             if (!strncmp(conCommand, c->cmd, lenString)) {
-                conAdd(LLOW, c->cmd);
+                conAdd(LNORM, c->cmd);
                 // this is the first command found, so lets save it as the most common word
                 if (!conCompWordsFoundCount) {
                     strcpy(conCompWord, c->cmd);
@@ -427,7 +427,7 @@ void conAutoComplete() {
     }
 
     if (!conCompWordsFoundCount) {
-        conAdd(LLOW, "No commands starting with %s", conCommand);
+        conAdd(LERR, "No commands starting with %s", conCommand);
         return;
     }
 

--- a/console.c
+++ b/console.c
@@ -58,11 +58,16 @@ void conAdd(int mode, char *f, ... ) {
     vsprintf (s, f, argptr);
     va_end (argptr);
 
+    printf("%s\n", s);
+
     if (strlen(s) >= CONSOLE_LENGTH-1)
         s[CONSOLE_LENGTH-1] = 0;
 
     if (mode > 3)
         mode = 0;
+
+    if (mode < LNORM) return;
+
 
     cpos++;
 
@@ -72,7 +77,6 @@ void conAdd(int mode, char *f, ... ) {
     strncpy(con[cpos].s, s, CONSOLE_LENGTH-1);
     memcpy(&con[cpos].c, &cols[mode], sizeof(con[cpos].c));
 
-    printf("%s\n", s);
 
 #if 0
     {

--- a/lua.c
+++ b/lua.c
@@ -138,13 +138,13 @@ int luag_load(lua_State *L) {
     
     char *s = (char*)lua_tostring(L, -1);
     char *f;
-    conAdd(1, s);
+    conAdd(LLOW, s);
     lua_pop(L, 1);
     
     s = va("spawn/%s", s);
     
     f = findFile(s);
-    conAdd(1, f);
+    conAdd(LLOW, f);
     
     luaExecute(findFile(f));
     
@@ -197,7 +197,7 @@ int luag_spawn(lua_State *L) {
 int luag_log(lua_State *L) {
 
     char *s = (char*)lua_tostring(L, -1);
-    conAdd(1, s);
+    conAdd(LNORM, s);
     lua_pop(L,1);
 
     return 0;

--- a/main.c
+++ b/main.c
@@ -232,7 +232,7 @@ int init(int argc, char *argv[]) {
 #endif
 
 #ifdef _OPENMP
-    conAdd(LLOW, "multi-threaded rendering: max threads = %d.    Found %d processors.", 
+    conAdd(LHELP, "multi-threaded rendering: max threads = %d.    Found %d processors.", 
                   state.processFrameThreads, omp_get_num_procs());
 #endif
 

--- a/spawn/default.gravitspawn
+++ b/spawn/default.gravitspawn
@@ -7,7 +7,7 @@ r = math.random(1,n)
 log("Spawning " .. scripts[r])
 
 file = scripts[r] .. ".gravitspawn"
-log(file)
+-- log(file)
 
 spawn = nil
 load(file)


### PR DESCRIPTION
... I always found that there is too much text in the gravit console area.
This patch hides all LLOW messages (but still writes them to stdout).
