### PR TITLE
gravit: fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/gravit.h
+++ b/src/gravit.h
@@ -683,23 +683,11 @@ typedef struct pib_s {
 } pib_t;
 
 // main.c
-#ifdef WIN32
-
 #ifndef NO_GUI
 extern video_t video;
 #endif
 extern state_t state;
 extern view_t view;
-
-#else
-
-#ifndef NO_GUI
-video_t video;
-#endif
-state_t state;
-view_t view;
-
-#endif
 
 void cleanMemory();
 void runVideo();


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: tool.o:(.bss+0x0): multiple definition of `view'; color.o:(.bss+0x0): first defined here
    ld: tool.o:(.bss+0x820): multiple definition of `video'; color.o:(.bss+0x820): first defined here
    ld: png_save.o:(.bss+0x0): multiple definition of `view'; color.o:(.bss+0x0): first defined here

The change leaves variable definitions only in C files.